### PR TITLE
feat: cycle diagnostics and generalized Kosaraju SCC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,8 +28,9 @@ moon info && moon fmt          # before committing
 - **Iter-based trait:** `DirectedGraph` requires `iter() -> Iter[Int]` and `successors(v) -> Iter[Int]` (pull-based). Callback methods `each_vertex`/`each_successor` are defaulted. `has_vertex` short-circuits via `Iter::contains`.
 - **Predecessors trait:** Optional capability trait for reverse-direction queries. `AdjacencyMap` and `DenseGraph` both implement it via bidirectional adjacency storage. Enables `Reversed[G]` zero-cost adaptor.
 - **Iterative algorithms:** DFS and SCC use explicit stacks, not recursion (tested up to 10K+ vertices)
-- **SCC algorithms:** Kosaraju (`AdjacencyMap::scc`, O(1) transpose) and Tarjan (`tarjan_scc`, generic over `DirectedGraph`, no transpose)
-- **All algorithms** are generic over `DirectedGraph` (except Kosaraju SCC and condensation)
+- **SCC algorithms:** Kosaraju (`kosaraju_scc`, generic over `DirectedGraph + Predecessors`, reverse-topo order; `AdjacencyMap::scc` is a thin wrapper) and Tarjan (`tarjan_scc`, generic over `DirectedGraph`, no `Predecessors` required, forward-topo order)
+- **All algorithms** are generic over `DirectedGraph` (condensation is still `AdjacencyMap`-only because it constructs a new graph)
+- **Cycle diagnostics:** `toposort_or_cycle` returns `Result[order, cycle_witness]`; `find_cycle` extracts one cycle path; `would_create_cycle(g, u, v)` predicts whether adding edge u→v creates a cycle (cheaper than `has_cycle` on the hypothetical graph)
 - **Property tests:** All 8 algebraic graph laws (Mokhov 2017) verified with `moonbitlang/quickcheck`
 - **External dep:** `moonbitlang/quickcheck` (aliased `@qc`) for property-based testing with shrinking
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5,9 +5,11 @@ Active backlog for alga. Each item links to its source; non-trivial items should
 ## Active
 
 - **DenseGraph promotion** — `DenseGraph` is proven (8–23x) and already `pub(all)` in `src/dense_graph.mbt` with `DirectedGraph` impl. Verify API design is finalized and close out remaining experiment-only code. Source: [EXPERIMENT_REPORT.md](../src/experiment/EXPERIMENT_REPORT.md#what-remains)
+- **Conformance test kit for `DirectedGraph` impls** — Property-test helper adopters call on their own impl: `iter() ∪ successors*(iter())` closure, no duplicate successors, `has_vertex` consistent with `iter`, etc. Addresses the contract-violation risk Codex flagged on PR #31 (vertices yielded by `successors` but missing from `iter`) without changing the trait or algorithms. Zero runtime cost on compliant graphs. Source: [PR #31 review](https://github.com/dowdiness/alga/pull/31)
 
 ## Investigate
 
+- **Split `DirectedGraph` into `VertexSet` + `Successors`** — Crisper contract: algorithms needing exhaustive iteration (toposort, SCC, `topo_levels`) require both; local queries (`reachable`, `is_reachable`, `would_create_cycle`) require only `Successors`. Lets adopters honestly impl successor-only graphs (e.g. pure functions with no enumerable vertex set). Wider refactor than the conformance kit — touches every impl. Revisit after the conformance kit lands and if `loom/incr` or another adopter hits a concrete successors-only case. Source: [PR #31 review](https://github.com/dowdiness/alga/pull/31)
 - **NodeFiltered graph adaptor** — `NodeFiltered[G]` implementing `DirectedGraph` without allocation. Cheap subgraph views for scope-restricted traversals. Source: [petgraph analysis](specs/2026-04-01-petgraph-analysis.md#1-zero-copy-graph-adaptors)
 - **Traversal control flow** — Early termination for push-style callbacks beyond what `Iter::contains` provides. `has_vertex` short-circuiting is now solved by the iter-based trait. Remaining: `dfs_fold`/`bfs_fold` callback could benefit from `ControlFlow` enum. Source: [petgraph analysis](specs/2026-04-01-petgraph-analysis.md#4-traversal-control-flow)
 - **GenCounter for visited sets** — Proven 2.4–5.5x faster than `Array[Bool]`, but production algorithms still use `Array[Bool]`. Tied to DenseGraph decision (requires dense vertex IDs). Source: [EXPERIMENT_REPORT.md](../src/experiment/EXPERIMENT_REPORT.md#what-remains)

--- a/src/dfs.mbt
+++ b/src/dfs.mbt
@@ -85,6 +85,60 @@ pub fn[G : DirectedGraph] reachable(graph : G, start : Int) -> Array[Int] {
 }
 
 ///|
+/// Early-exit reachability query: "is `to` reachable from `from`?"
+///
+/// Runs DFS from `from` and stops as soon as `to` is discovered, without
+/// materializing the full reachable set. Reflexive: `is_reachable(g, v, v)`
+/// is true (zero-length path), matching the behaviour of `reachable(g, v)`
+/// which includes `v` in its output.
+///
+/// Returns `false` if `from` is not a vertex in the graph.
+///
+/// Time: O(V' + E') where V' and E' are the vertices and edges visited
+/// before encountering `to` (bounded by the reachable subgraph from `from`).
+pub fn[G : DirectedGraph] is_reachable(graph : G, from : Int, to : Int) -> Bool {
+  if !G::has_vertex(graph, from) {
+    return false
+  }
+  dfs_fold(graph, from, false, fn(_, v) {
+    if v == to {
+      (true, false)
+    } else {
+      (false, true)
+    }
+  })
+}
+
+///|
+/// Would adding edge `u -> v` introduce a cycle?
+///
+/// A new edge `u -> v` closes a cycle iff there already exists a path
+/// `v -> ... -> u` in the graph (then `u -> v -> ... -> u` is cyclic).
+/// Self-loops (`u == v`) always create a cycle.
+///
+/// Useful for movable-tree CRDTs and reactive-graph libraries that must
+/// reject cycle-creating edges before committing them. Strictly cheaper
+/// than `has_cycle` on the hypothetical graph: early-exits as soon as the
+/// closing path is found.
+///
+/// Does not require `u` or `v` to already be in the graph — a missing
+/// endpoint cannot participate in any existing path, so no cycle is
+/// possible unless `u == v`.
+///
+/// Time: O(V' + E') where V' and E' are the vertices and edges visited
+/// searching from `v` for `u` (bounded by v's reachable subgraph).
+pub fn[G : DirectedGraph] would_create_cycle(
+  graph : G,
+  u : Int,
+  v : Int,
+) -> Bool {
+  if u == v {
+    return true
+  }
+  is_reachable(graph, v, u)
+}
+
+///|
 /// Multi-source DFS fold over vertices reachable from any vertex in `starts`.
 ///
 /// Seeds the DFS stack with all start vertices instead of one, enabling

--- a/src/dfs_test.mbt
+++ b/src/dfs_test.mbt
@@ -540,3 +540,83 @@ test "reversed preserves has_cycle" {
   let acyclic = @alga.AdjacencyMap::from_edges([(0, 1), (1, 2)])
   assert_true(!@alga.has_cycle(@alga.reversed(acyclic)))
 }
+
+///|
+test "is_reachable simple" {
+  let g = @alga.AdjacencyMap::from_edges([(1, 2), (2, 3), (3, 4)])
+  assert_true(@alga.is_reachable(g, 1, 4))
+  assert_true(@alga.is_reachable(g, 2, 4))
+  assert_true(!@alga.is_reachable(g, 4, 1))
+  assert_true(!@alga.is_reachable(g, 3, 2))
+}
+
+///|
+test "is_reachable reflexive on present vertex" {
+  let g = @alga.AdjacencyMap::from_edges([(1, 2)])
+  assert_true(@alga.is_reachable(g, 1, 1))
+  assert_true(@alga.is_reachable(g, 2, 2))
+}
+
+///|
+test "is_reachable missing from-vertex" {
+  let g = @alga.AdjacencyMap::from_edges([(1, 2)])
+  assert_true(!@alga.is_reachable(g, 99, 1))
+  assert_true(!@alga.is_reachable(g, 99, 99))
+}
+
+///|
+test "is_reachable disconnected components" {
+  let g = @alga.AdjacencyMap::from_edges([(1, 2), (3, 4)])
+  assert_true(@alga.is_reachable(g, 1, 2))
+  assert_true(@alga.is_reachable(g, 3, 4))
+  assert_true(!@alga.is_reachable(g, 1, 3))
+  assert_true(!@alga.is_reachable(g, 1, 4))
+}
+
+///|
+test "is_reachable in cycle" {
+  let g = @alga.AdjacencyMap::from_edges([(1, 2), (2, 3), (3, 1)])
+  assert_true(@alga.is_reachable(g, 1, 2))
+  assert_true(@alga.is_reachable(g, 2, 1))
+  assert_true(@alga.is_reachable(g, 3, 2))
+}
+
+///|
+test "would_create_cycle self-loop" {
+  let g : @alga.AdjacencyMap = @alga.AdjacencyMap::empty()
+  assert_true(@alga.would_create_cycle(g, 5, 5))
+  let g2 = @alga.AdjacencyMap::from_edges([(1, 2)])
+  assert_true(@alga.would_create_cycle(g2, 1, 1))
+}
+
+///|
+test "would_create_cycle closes path" {
+  // g: 1 -> 2 -> 3. Adding 3 -> 1 creates cycle.
+  let g = @alga.AdjacencyMap::from_edges([(1, 2), (2, 3)])
+  assert_true(@alga.would_create_cycle(g, 3, 1))
+  assert_true(@alga.would_create_cycle(g, 2, 1))
+}
+
+///|
+test "would_create_cycle no cycle" {
+  // g: 1 -> 2 -> 3. Adding 1 -> 3 does not create cycle.
+  let g = @alga.AdjacencyMap::from_edges([(1, 2), (2, 3)])
+  assert_true(!@alga.would_create_cycle(g, 1, 3))
+  assert_true(!@alga.would_create_cycle(g, 1, 2))
+}
+
+///|
+test "would_create_cycle disconnected" {
+  // Endpoints in separate components — never a cycle unless u == v.
+  let g = @alga.AdjacencyMap::from_edges([(1, 2), (3, 4)])
+  assert_true(!@alga.would_create_cycle(g, 1, 3))
+  assert_true(!@alga.would_create_cycle(g, 3, 1))
+}
+
+///|
+test "would_create_cycle endpoints missing" {
+  // Vertices not in graph — no existing paths, no cycle (unless self-loop).
+  let g : @alga.AdjacencyMap = @alga.AdjacencyMap::empty()
+  assert_true(!@alga.would_create_cycle(g, 1, 2))
+  assert_true(@alga.would_create_cycle(g, 7, 7))
+}

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -17,6 +17,8 @@ pub fn[G : DirectedGraph, Acc] dfs_fold(G, Int, Acc, (Acc, Int) -> (Acc, Bool)) 
 
 pub fn[G : DirectedGraph, Acc] dfs_fold_multi(G, Array[Int], Acc, (Acc, Int) -> (Acc, Bool)) -> Acc
 
+pub fn[G : DirectedGraph] find_cycle(G) -> Array[Int]?
+
 pub fn[B] foldg(Graph, B, (Int) -> B, (B, B) -> B, (B, B) -> B) -> B
 
 pub fn[B] foldg_iter(Graph, B, (Int) -> B, (B, B) -> B, (B, B) -> B) -> B
@@ -24,6 +26,10 @@ pub fn[B] foldg_iter(Graph, B, (Int) -> B, (B, B) -> B, (B, B) -> B) -> B
 pub fn[G : DirectedGraph] has_cycle(G) -> Bool
 
 pub fn[G : DirectedGraph] indegree(G, Int) -> Int
+
+pub fn[G : DirectedGraph] is_reachable(G, Int, Int) -> Bool
+
+pub fn[G : DirectedGraph + Predecessors] kosaraju_scc(G) -> Array[Array[Int]]
 
 pub fn[G : DirectedGraph] outdegree(G, Int) -> Int
 
@@ -39,7 +45,11 @@ pub fn[G : DirectedGraph] topo_levels(G) -> Map[Int, Int]?
 
 pub fn[G : DirectedGraph] toposort(G) -> Array[Int]?
 
+pub fn[G : DirectedGraph] toposort_or_cycle(G) -> Result[Array[Int], Array[Int]]
+
 pub fn[G : DirectedGraph] toposort_subset(G, Array[Int]) -> Array[Int]?
+
+pub fn[G : DirectedGraph] would_create_cycle(G, Int, Int) -> Bool
 
 // Errors
 

--- a/src/scc.mbt
+++ b/src/scc.mbt
@@ -26,71 +26,82 @@
 /// in the same SCC (because reachability in the transpose means
 /// reverse-reachability in the original).
 ///
-/// ## Why AdjacencyMap, not DirectedGraph?
+/// ## Generic over Predecessors
 ///
-/// Kosaraju SCC requires `transpose()`. With bidirectional adjacency
-/// storage, transpose is O(1) (field swap). This method stays on
-/// `AdjacencyMap` for API stability, but a generic Kosaraju over
-/// `DirectedGraph + Predecessors` is now feasible via `Reversed[G]`.
-/// See also `tarjan_scc` which is already generic (no transpose needed).
+/// `kosaraju_scc` works on any `DirectedGraph + Predecessors` — the backward
+/// DFS walks `predecessors` directly rather than materializing a transposed
+/// graph, avoiding the O(V+E) transpose allocation. `AdjacencyMap::scc`
+/// is a thin wrapper. See also `tarjan_scc` (single pass, no `Predecessors`
+/// requirement, forward-topo ordering).
 ///
 /// ## Implementation: fully iterative
 ///
-/// Both DFS passes use explicit stacks instead of recursion.
-/// The forward DFS uses `(vertex, successor_index)` frames to simulate
-/// the recursive call stack and correctly record post-order finish times.
+/// Both DFS passes use explicit stacks instead of recursion. Stack frames
+/// carry `Iter[Int]` (same pause/resume trick as `tarjan_scc`) so recording
+/// post-order finish times doesn't require a successor-index counter.
 ///
-/// Time: O(V + E). Space: O(V + E) for the transposed graph.
+/// Time: O(V + E). Space: O(V).
 
 ///|
-/// Compute all strongly connected components.
+/// Compute all strongly connected components via Kosaraju's algorithm.
+///
+/// Generic over `DirectedGraph + Predecessors` — the second DFS pass walks
+/// `predecessors` directly instead of materializing a transposed graph,
+/// saving the O(V+E) transpose allocation.
 ///
 /// Returns components in reverse topological order of the component DAG
 /// (if A's component has an edge to B's component, A's component appears
-/// first in the result).
-pub fn AdjacencyMap::scc(self : AdjacencyMap) -> Array[Array[Int]] {
-  // Pass 1: Forward DFS — record finish order
-  // Uses (vertex, successor_index) stack frames to track post-order
+/// first in the result). This matches the classical Kosaraju ordering and
+/// is the *opposite* of `tarjan_scc`.
+///
+/// ## When to use which SCC
+///
+/// - `kosaraju_scc`: when `Predecessors` is available and you want reverse
+///   topological order, or benefit from the two-pass structure (e.g. you
+///   already needed finish order for something else).
+/// - `tarjan_scc`: when you lack `Predecessors`, or want forward topological
+///   order.
+///
+/// Time: O(V + E). Space: O(V) — no transpose allocation.
+pub fn[G : DirectedGraph + Predecessors] kosaraju_scc(
+  graph : G,
+) -> Array[Array[Int]] {
+  // Pass 1: Forward DFS — record finish order.
+  // Stack frames: (vertex, Iter[Int]) — iterator carries successor position,
+  // matching tarjan_scc's approach and avoiding temp-array allocation.
   let visited : Map[Int, Bool] = Map::new()
   let finish_order : Array[Int] = []
-  for root, _ in self.adjacency {
-    if visited.get(root) == Some(true) {
+  let frames : Array[(Int, Iter[Int])] = []
+  for root in G::iter(graph) {
+    if visited.contains(root) {
       continue
     }
-    let stack : Array[(Int, Int)] = [(root, 0)]
     visited[root] = true
-    while stack.length() > 0 {
-      let top_idx = stack.length() - 1
-      let v = stack[top_idx].0
-      let si = stack[top_idx].1
-      let succs = match self.adjacency.get(v) {
-        Some(s) => s
-        None => []
-      }
-      if si < succs.length() {
-        // Advance to next successor
-        stack[top_idx] = (v, si + 1)
-        let w = succs[si]
-        if visited.get(w) != Some(true) {
-          visited[w] = true
-          stack.push((w, 0))
+    frames.push((root, G::successors(graph, root)))
+    while frames.length() > 0 {
+      let top_idx = frames.length() - 1
+      let v = frames[top_idx].0
+      let iter = frames[top_idx].1
+      match iter.next() {
+        Some(w) =>
+          if !visited.contains(w) {
+            visited[w] = true
+            frames.push((w, G::successors(graph, w)))
+          }
+        None => {
+          finish_order.push(v)
+          let _ = frames.unsafe_pop()
         }
-      } else {
-        // All successors explored — record finish time
-        let _ = stack.unsafe_pop()
-        finish_order.push(v)
       }
     }
   }
-  // Pass 2: Transpose the graph (reverse all edges)
-  let transposed = self.transpose()
-  // Pass 3: Backward DFS in reverse finish order
-  // Each DFS tree on the transposed graph is one SCC
+  // Pass 2: Backward DFS in reverse finish order, walking predecessors.
+  // Each DFS tree on the reverse graph is one SCC.
   let visited2 : Map[Int, Bool] = Map::new()
   let components : Array[Array[Int]] = []
   for i in (finish_order.length() - 1)>=..0 {
     let root = finish_order[i]
-    if visited2.get(root) == Some(true) {
+    if visited2.contains(root) {
       continue
     }
     let component : Array[Int] = []
@@ -99,21 +110,25 @@ pub fn AdjacencyMap::scc(self : AdjacencyMap) -> Array[Array[Int]] {
     while stack.length() > 0 {
       let v = stack.unsafe_pop()
       component.push(v)
-      match transposed.adjacency.get(v) {
-        Some(succs) =>
-          for j in (succs.length() - 1)>=..0 {
-            let w = succs[j]
-            if visited2.get(w) != Some(true) {
-              visited2[w] = true
-              stack.push(w)
-            }
-          }
-        None => ()
-      }
+      Predecessors::predecessors(graph, v).each(fn(w) {
+        if !visited2.contains(w) {
+          visited2[w] = true
+          stack.push(w)
+        }
+      })
     }
     components.push(component)
   }
   components
+}
+
+///|
+/// Compute all strongly connected components.
+///
+/// Thin wrapper over the generic `kosaraju_scc` — see its doc comment for
+/// ordering and complexity guarantees.
+pub fn AdjacencyMap::scc(self : AdjacencyMap) -> Array[Array[Int]] {
+  kosaraju_scc(self)
 }
 
 ///|

--- a/src/scc_test.mbt
+++ b/src/scc_test.mbt
@@ -326,3 +326,33 @@ test "tarjan_scc works on DenseGraph" {
   assert_true(cycle_comp.contains(2))
   assert_eq(singleton_comp[0], 3)
 }
+
+///|
+test "kosaraju_scc generic on DenseGraph" {
+  // DenseGraph implements DirectedGraph + Predecessors — verifies the
+  // generalization really works on a non-AdjacencyMap type.
+  let g = @alga.DenseGraph::from_edges(4, [(0, 1), (1, 2), (2, 0), (2, 3)])
+  let sccs = @alga.kosaraju_scc(g)
+  assert_eq(sccs.length(), 2)
+  // Components: {0,1,2} and {3}. Kosaraju emits reverse-topo order, so the
+  // cycle component (which has an outgoing edge to {3}) comes first.
+  let cycle_comp = sccs[0]
+  let singleton = sccs[1]
+  assert_eq(cycle_comp.length(), 3)
+  assert_true(cycle_comp.contains(0))
+  assert_true(cycle_comp.contains(1))
+  assert_true(cycle_comp.contains(2))
+  assert_eq(singleton.length(), 1)
+  assert_eq(singleton[0], 3)
+}
+
+///|
+test "kosaraju_scc on reversed graph" {
+  // Reversed[G] implements DirectedGraph + Predecessors too.
+  let g = @alga.AdjacencyMap::from_edges([(1, 2), (2, 3), (3, 1), (2, 4)])
+  let direct = @alga.kosaraju_scc(g)
+  let via_reversed = @alga.kosaraju_scc(@alga.reversed(g))
+  // SCC membership is direction-invariant — the same partitions appear,
+  // though emission order may differ.
+  assert_eq(direct.length(), via_reversed.length())
+}

--- a/src/toposort.mbt
+++ b/src/toposort.mbt
@@ -104,6 +104,109 @@ pub fn[G : DirectedGraph] has_cycle(graph : G) -> Bool {
 }
 
 ///|
+/// Find a directed cycle, if any.
+///
+/// Returns `Some(path)` where `path = [v0, v1, ..., vk]` and there is an
+/// edge `vk -> v0` closing the cycle, or `None` if the graph is acyclic.
+/// Self-loops are returned as `[v]` (single vertex; the closing edge is
+/// `v -> v`).
+///
+/// ## Algorithm
+///
+/// Iterative three-color DFS (white = unseen, gray = on current path,
+/// black = finished). When a gray successor is found, the cycle runs from
+/// that ancestor down through the current DFS frame stack. The closing
+/// edge is from the last element back to the first.
+///
+/// The returned path is one witness — there may be others. No ordering
+/// guarantee across graphs, but for a given graph traversal the output is
+/// deterministic (controlled by `iter` and `successors` order).
+///
+/// Time: O(V + E) worst case (acyclic graph). Early-exits on first cycle.
+/// Space: O(V).
+pub fn[G : DirectedGraph] find_cycle(graph : G) -> Array[Int]? {
+  // state: absent = white, true = gray (on stack), false = black (finished)
+  let state : Map[Int, Bool] = Map::new()
+  // position[v] = frame index of v while v is gray, enabling O(1) cycle
+  // extraction when a back-edge is encountered.
+  let position : Map[Int, Int] = Map::new()
+  let frames : Array[(Int, Iter[Int])] = []
+  for root in G::iter(graph) {
+    if state.contains(root) {
+      continue
+    }
+    state[root] = true
+    position[root] = 0
+    frames.push((root, G::successors(graph, root)))
+    while frames.length() > 0 {
+      let top_idx = frames.length() - 1
+      let v = frames[top_idx].0
+      let iter = frames[top_idx].1
+      match iter.next() {
+        Some(w) =>
+          match state.get(w) {
+            None => {
+              // Tree edge: descend into w
+              state[w] = true
+              position[w] = frames.length()
+              frames.push((w, G::successors(graph, w)))
+            }
+            Some(true) => {
+              // Back edge v -> w: w is an ancestor on the current path.
+              // Extract cycle from frames[position[w]..=top_idx].
+              let start = position[w]
+              let cycle : Array[Int] = []
+              for i in start..<=top_idx {
+                cycle.push(frames[i].0)
+              }
+              return Some(cycle)
+            }
+            Some(false) => ()
+            // Cross/forward edge — not a cycle on this path
+          }
+        None => {
+          // All successors done — finish v
+          state[v] = false
+          position.remove(v)
+          let _ = frames.unsafe_pop()
+        }
+      }
+    }
+  }
+  None
+}
+
+///|
+/// Topological sort that returns the witnessing cycle on failure.
+///
+/// `Ok(ordering)` for DAGs, `Err(cycle)` where `cycle = [v0, ..., vk]` with
+/// a closing edge `vk -> v0` when the graph has a cycle. Strictly more
+/// informative than `toposort` — use this when the caller wants to
+/// diagnose or report the cycle (reactive-graph cycle paths, movable-tree
+/// conflict diagnostics, build-system dependency errors).
+///
+/// Runs `toposort` first (O(V+E), Kahn's algorithm) and falls back to
+/// `find_cycle` on failure — so the acyclic path pays the same cost as
+/// plain `toposort`.
+pub fn[G : DirectedGraph] toposort_or_cycle(
+  graph : G,
+) -> Result[Array[Int], Array[Int]] {
+  match toposort(graph) {
+    Some(order) => Ok(order)
+    None =>
+      match find_cycle(graph) {
+        Some(cycle) => Err(cycle)
+        // Only reachable if the `DirectedGraph` contract is violated:
+        // `toposort` counts `successors(v)` vertices missing from `iter()`
+        // against its completeness check, while `find_cycle` only roots
+        // from `iter()`. On contract-compliant graphs this branch is dead.
+        // Return an empty witness rather than panic.
+        None => Err([])
+      }
+  }
+}
+
+///|
 /// # Topological Levels
 ///
 /// Computes the length of the longest path from any source (zero-in-degree

--- a/src/toposort_test.mbt
+++ b/src/toposort_test.mbt
@@ -390,3 +390,86 @@ test "topo_levels asymmetric paths (longest wins)" {
     None => assert_true(false)
   }
 }
+
+///|
+test "find_cycle acyclic" {
+  let g = @alga.AdjacencyMap::from_edges([(1, 2), (2, 3), (3, 4)])
+  assert_true(@alga.find_cycle(g) is None)
+}
+
+///|
+test "find_cycle self-loop" {
+  let g = @alga.AdjacencyMap::from_edges([(1, 2), (2, 2)])
+  match @alga.find_cycle(g) {
+    Some(cycle) => {
+      assert_eq(cycle.length(), 1)
+      assert_eq(cycle[0], 2)
+    }
+    None => assert_true(false)
+  }
+}
+
+///|
+test "find_cycle triangle" {
+  let g = @alga.AdjacencyMap::from_edges([(1, 2), (2, 3), (3, 1)])
+  match @alga.find_cycle(g) {
+    Some(cycle) => {
+      assert_eq(cycle.length(), 3)
+      // Cycle contains all three vertices in some rotation.
+      assert_true(cycle.contains(1))
+      assert_true(cycle.contains(2))
+      assert_true(cycle.contains(3))
+      // Closing edge (cycle[last] -> cycle[0]) must actually exist.
+      let first = cycle[0]
+      let last = cycle[cycle.length() - 1]
+      assert_true(g.has_edge(last, first))
+    }
+    None => assert_true(false)
+  }
+}
+
+///|
+test "find_cycle finds cycle ignoring dag prefix" {
+  // 1 -> 2 -> 3 -> 4 -> 3 (cycle between 3 and 4)
+  let g = @alga.AdjacencyMap::from_edges([(1, 2), (2, 3), (3, 4), (4, 3)])
+  match @alga.find_cycle(g) {
+    Some(cycle) => {
+      assert_true(cycle.contains(3))
+      assert_true(cycle.contains(4))
+      assert_eq(cycle.length(), 2)
+    }
+    None => assert_true(false)
+  }
+}
+
+///|
+test "toposort_or_cycle ok" {
+  let g = @alga.AdjacencyMap::from_edges([(1, 2), (2, 3)])
+  match @alga.toposort_or_cycle(g) {
+    Ok(order) => {
+      assert_eq(order.length(), 3)
+      // Verify order is a valid topological order.
+      let pos : Map[Int, Int] = Map::new()
+      for i, v in order {
+        pos[v] = i
+      }
+      assert_true(pos[1] < pos[2])
+      assert_true(pos[2] < pos[3])
+    }
+    Err(_) => assert_true(false)
+  }
+}
+
+///|
+test "toposort_or_cycle err returns cycle witness" {
+  let g = @alga.AdjacencyMap::from_edges([(1, 2), (2, 3), (3, 1)])
+  match @alga.toposort_or_cycle(g) {
+    Ok(_) => assert_true(false)
+    Err(cycle) => {
+      assert_eq(cycle.length(), 3)
+      let first = cycle[0]
+      let last = cycle[cycle.length() - 1]
+      assert_true(g.has_edge(last, first))
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a batch of graph-query primitives to unblock adopters that need cycle detection/prevention (`loom/incr` reactive graph, movable-tree CRDT) and gives Kosaraju the same generic surface as Tarjan.

### New public API

- `is_reachable(g, from, to) -> Bool` — early-exit DFS. Reflexive (`is_reachable(g, v, v) == true`, matching `reachable(g, v)` which includes `v`). Returns `false` if `from` not in graph.
- `would_create_cycle(g, u, v) -> Bool` — predicts whether adding edge `u -> v` creates a cycle. Equivalent to `is_reachable(g, v, u)`; self-loop (`u == v`) is always true. Strictly cheaper than constructing the hypothetical graph and calling `has_cycle`.
- `find_cycle(g) -> Array[Int]?` — iterative 3-color DFS returning one cycle witness `[v0..vk]` where `vk -> v0` is the closing edge. Self-loops return `[v]`.
- `toposort_or_cycle(g) -> Result[Array[Int], Array[Int]]` — Kahn's toposort on success, `find_cycle` witness on failure. Strictly more informative than `toposort`.
- `kosaraju_scc(g)` — generic over `DirectedGraph + Predecessors`. Walks `predecessors` directly instead of materializing a transposed graph, saving the O(V+E) transpose allocation. `AdjacencyMap::scc` becomes a thin wrapper.

### Non-goals (deliberately deferred)

- `VertexMap[T]` interning helper, conformance test kit, mutable graph type, LCA queries, `Graph[T]` generic construction, weighted edges. These either need design docs or are waiting for a concrete caller.

### Review

Codex reviewed — no bugs. Three risks flagged, all variations of the same root cause: behavior under `DirectedGraph` contract violations (where `successors(v)` yields vertices missing from `iter()`). Pre-existing `toposort` has identical behavior. One misleading comment in `toposort_or_cycle` updated to reflect this honestly.

### Stats

- 8 files changed, 431 insertions, 55 deletions
- `src/pkg.generated.mbti`: +10 lines, no removals (purely additive)
- 255/255 tests passing (237 baseline + 18 new)

## Test plan

- [x] `moon check` clean
- [x] `moon test` — 255/255 pass
- [x] `moon info && moon fmt` clean; `.mbti` diff reviewed (additive only)
- [ ] CI green on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)