### PR TITLE
feat: DirectedGraph conformance test kit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ moon info && moon fmt          # before committing
 - **SCC algorithms:** Kosaraju (`kosaraju_scc`, generic over `DirectedGraph + Predecessors`, reverse-topo order; `AdjacencyMap::scc` is a thin wrapper) and Tarjan (`tarjan_scc`, generic over `DirectedGraph`, no `Predecessors` required, forward-topo order)
 - **All algorithms** are generic over `DirectedGraph` (condensation is still `AdjacencyMap`-only because it constructs a new graph)
 - **Cycle diagnostics:** `toposort_or_cycle` returns `Result[order, cycle_witness]`; `find_cycle` extracts one cycle path; `would_create_cycle(g, u, v)` predicts whether adding edge u→v creates a cycle (cheaper than `has_cycle` on the hypothetical graph)
+- **Conformance kit:** `check_conformance(g)` and `check_predecessors_conformance(g)` return a list of violations for adopters to run in their own test suites. Test-time only — catches contract violations (dangling successors, duplicate iter, predecessor/successor asymmetry) that algorithms would otherwise silently misbehave on.
 - **Property tests:** All 8 algebraic graph laws (Mokhov 2017) verified with `moonbitlang/quickcheck`
 - **External dep:** `moonbitlang/quickcheck` (aliased `@qc`) for property-based testing with shrinking
 

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -5,7 +5,6 @@ Active backlog for alga. Each item links to its source; non-trivial items should
 ## Active
 
 - **DenseGraph promotion** — `DenseGraph` is proven (8–23x) and already `pub(all)` in `src/dense_graph.mbt` with `DirectedGraph` impl. Verify API design is finalized and close out remaining experiment-only code. Source: [EXPERIMENT_REPORT.md](../src/experiment/EXPERIMENT_REPORT.md#what-remains)
-- **Conformance test kit for `DirectedGraph` impls** — Property-test helper adopters call on their own impl: `iter() ∪ successors*(iter())` closure, no duplicate successors, `has_vertex` consistent with `iter`, etc. Addresses the contract-violation risk Codex flagged on PR #31 (vertices yielded by `successors` but missing from `iter`) without changing the trait or algorithms. Zero runtime cost on compliant graphs. Source: [PR #31 review](https://github.com/dowdiness/alga/pull/31)
 
 ## Investigate
 
@@ -18,6 +17,8 @@ Active backlog for alga. Each item links to its source; non-trivial items should
 
 ## Done
 
+- **~~Conformance test kit for `DirectedGraph` impls~~** — `check_conformance(g) -> Array[String]` and `check_predecessors_conformance(g)` verify laws A–G (iter uniqueness, successor closure, has_vertex consistency, vertex_count agreement, successor/predecessor dedup, each_* defaults-vs-override agreement, forward/backward edge symmetry). Addresses the contract-violation risk Codex flagged on PR #31.
+- **~~Cycle diagnostics + generalized Kosaraju~~** — `is_reachable`, `would_create_cycle`, `find_cycle`, `toposort_or_cycle` (`Result[order, witness]`), and `kosaraju_scc` generic over `DirectedGraph + Predecessors`. Source: [PR #31](https://github.com/dowdiness/alga/pull/31)
 - **~~Reversed graph adaptor~~** — `Reversed[G]` zero-cost newtype + `Predecessors` capability trait + bidirectional adjacency in `AdjacencyMap`/`DenseGraph`. `transpose()` is now O(1). Source: [spec](specs/2026-04-01-reversed-graph-adaptor-design.md)
 - **~~DFS edge classification~~** — `dfs_events(graph) -> Iter[DfsEvent]` with 5 events: Discover, Finish, TreeEdge, BackEdge, CrossForwardEdge. Pull-based iterator, generic over `DirectedGraph`. Source: [spec](specs/2026-04-01-dfs-edge-classification-design.md)
 - **~~Iter-based DirectedGraph trait + Tarjan SCC~~** — Migrated trait from CPS callbacks (`for_each_vertex`/`for_each_successor`) to `Iter[Int]`-based (`iter`/`successors`). Added `tarjan_scc` generic over `DirectedGraph` — single-pass, no transpose. `has_vertex` now short-circuits via `Iter::contains`. Source: [spec](specs/2026-04-01-iter-based-trait-and-tarjan-design.md)

--- a/src/conformance.mbt
+++ b/src/conformance.mbt
@@ -98,7 +98,7 @@ pub fn[G : DirectedGraph] check_conformance(graph : G) -> Array[String] {
   // Negative consistency: pick a few candidate vertices that could not
   // have come from iter (max+1, min-1, and a large-magnitude sentinel)
   // and require has_vertex returns false.
-  let outside = outside_candidates(iter_raw)
+  let outside = outside_candidates(iter_set)
   for v in outside {
     if G::has_vertex(graph, v) {
       violations.push(
@@ -145,18 +145,18 @@ pub fn[G : DirectedGraph] check_conformance(graph : G) -> Array[String] {
 }
 
 ///|
-/// Pick a small set of vertex IDs guaranteed not to be in `iter_raw`.
+/// Pick a small set of vertex IDs guaranteed not to be in `iter_set`.
 /// Used for Law C negative consistency — we can't enumerate the complement
 /// of iter(), but we can spot-check sentinels that are guaranteed outside
 /// any finite vertex set we just observed.
-fn outside_candidates(iter_raw : Array[Int]) -> Array[Int] {
-  if iter_raw.length() == 0 {
+fn outside_candidates(iter_set : @hashset.HashSet[Int]) -> Array[Int] {
+  if iter_set.length() == 0 {
     // Any value works as "not in iter" when iter is empty.
     return [0, 1, -1, @int.MAX_VALUE, @int.MIN_VALUE]
   }
-  let mut lo = iter_raw[0]
-  let mut hi = iter_raw[0]
-  for v in iter_raw {
+  let mut lo = @int.MAX_VALUE
+  let mut hi = @int.MIN_VALUE
+  for v in iter_set {
     if v < lo {
       lo = v
     }
@@ -175,17 +175,7 @@ fn outside_candidates(iter_raw : Array[Int]) -> Array[Int] {
   candidates.push(@int.MIN_VALUE)
   // Filter out any candidate that somehow appeared (edge case if iter
   // contains both max and min): we want guaranteed-outside only.
-  let iter_set : @hashset.HashSet[Int] = @hashset.new()
-  for v in iter_raw {
-    iter_set.add(v)
-  }
-  let result : Array[Int] = []
-  for c in candidates {
-    if !iter_set.contains(c) {
-      result.push(c)
-    }
-  }
-  result
+  candidates.iter().filter(fn(c) { !iter_set.contains(c) }).collect()
 }
 
 ///|

--- a/src/conformance.mbt
+++ b/src/conformance.mbt
@@ -1,0 +1,266 @@
+///|
+/// # DirectedGraph conformance checks
+///
+/// Property-test helper for verifying that a `DirectedGraph` implementation
+/// honors the trait contract. Adopters call `check_conformance(g)` on
+/// graphs produced by their type (typically inside a test) and assert that
+/// the returned violation list is empty.
+///
+/// ## Why this exists
+///
+/// The `DirectedGraph` trait has an implicit contract — `iter()` yields
+/// every vertex exactly once, `successors(v)` only yields vertices that
+/// are also in `iter()`, `has_vertex` agrees with `iter`, and so on.
+/// Algorithms like `toposort`, `tarjan_scc`, and `find_cycle` silently
+/// misbehave on impls that violate this contract (missed subgraphs,
+/// wrong vertex counts, spurious cycles). A runtime contract check can't
+/// prevent this, but a test-time check can — run `check_conformance` in
+/// your impl's test suite on representative instances.
+///
+/// ## Laws checked
+///
+/// - **A.** `iter()` yields each vertex exactly once (no duplicates)
+/// - **B.** Closure: every `w ∈ successors(v)` is also in `iter()` for v ∈ `iter()`
+/// - **C.** `has_vertex(v) == true` for every v in `iter()`, and
+///   `has_vertex(v) == false` for a small spot-check of sentinel values
+///   known to be absent (MAX_VALUE, MIN_VALUE, and nearest out-of-range
+///   neighbours). **Limitation:** this is a spot check, not a proof —
+///   a pathological `has_vertex` that only lies on un-sampled vertices
+///   can still slip past. Treat the absent-vertex side as a sanity ward,
+///   not a guarantee.
+/// - **D.** `vertex_count() == iter().count()`
+/// - **E.** `successors(v)` contains no duplicates for each v
+/// - **F.** `each_vertex` / `each_successor` defaults agree with the `iter` / `successors` sources
+///
+/// Law G (Predecessors symmetry) is in `check_predecessors_conformance`,
+/// which also requires the `Predecessors` capability.
+///
+/// ## Return shape
+///
+/// Returns `Array[String]` — one human-readable line per violation.
+/// Empty array means the graph is conformant. Test callers typically do:
+///
+/// ```moonbit
+/// let violations = @alga.check_conformance(my_graph)
+/// assert_eq(violations, [])
+/// ```
+///
+/// The check is O(V + E) time and O(V + E) space. Not appropriate for
+/// production hot paths — this is a development-time correctness tool.
+
+///|
+/// Check that a graph conforms to the `DirectedGraph` trait contract.
+///
+/// Returns a list of human-readable violation messages; an empty list
+/// means the graph is conformant. See the module doc for the laws checked.
+pub fn[G : DirectedGraph] check_conformance(graph : G) -> Array[String] {
+  let violations : Array[String] = []
+  // Capture iter() output raw (with any duplicates preserved) and also
+  // build a deduplicated set for downstream closure checks.
+  // - iter_raw: what Laws D and F compare against, since the default
+  //   vertex_count/each_vertex delegate to iter() including duplicates.
+  // - iter_set: vertex membership oracle for Law B.
+  let iter_raw : Array[Int] = []
+  let iter_set : @hashset.HashSet[Int] = @hashset.new()
+  let dup_reported : @hashset.HashSet[Int] = @hashset.new()
+  for v in G::iter(graph) {
+    iter_raw.push(v)
+    if iter_set.contains(v) {
+      // Duplicate — report once per offending vertex, then keep going so
+      // downstream checks still run (membership remains correct).
+      if !dup_reported.contains(v) {
+        dup_reported.add(v)
+        violations.push("Law A: iter() yielded duplicate vertex \{v}")
+      }
+    } else {
+      iter_set.add(v)
+    }
+  }
+  // Law D: vertex_count agrees with the raw iter count. Defaults to
+  // iter().count() so duplicate-iter impls still satisfy this against
+  // the default; only a custom override can fail D in isolation.
+  let vc = G::vertex_count(graph)
+  if vc != iter_raw.length() {
+    violations.push(
+      "Law D: vertex_count() = \{vc} but iter().count() = \{iter_raw.length()}",
+    )
+  }
+  // Law C: has_vertex agrees with iter for present vertices, and returns
+  // false for vertices observably outside iter (spot-checked — we can't
+  // enumerate the complement).
+  for v in iter_set {
+    if !G::has_vertex(graph, v) {
+      violations.push(
+        "Law C: iter() yielded \{v} but has_vertex(\{v}) returned false",
+      )
+    }
+  }
+  // Negative consistency: pick a few candidate vertices that could not
+  // have come from iter (max+1, min-1, and a large-magnitude sentinel)
+  // and require has_vertex returns false.
+  let outside = outside_candidates(iter_raw)
+  for v in outside {
+    if G::has_vertex(graph, v) {
+      violations.push(
+        "Law C: has_vertex(\{v}) returned true but \{v} is not in iter()",
+      )
+    }
+  }
+  // Laws B + E: successors closure + no duplicates.
+  for v in iter_set {
+    let succ_seen : @hashset.HashSet[Int] = @hashset.new()
+    for w in G::successors(graph, v) {
+      if succ_seen.contains(w) {
+        violations.push("Law E: successors(\{v}) yielded duplicate vertex \{w}")
+      } else {
+        succ_seen.add(w)
+      }
+      if !iter_set.contains(w) {
+        violations.push(
+          "Law B: successors(\{v}) yielded \{w}, which is not in iter()",
+        )
+      }
+    }
+  }
+  // Law F: each_vertex agrees with iter() as a multiset (duplicates and all).
+  let ev_list : Array[Int] = []
+  G::each_vertex(graph, fn(v) { ev_list.push(v) })
+  if !multiset_eq(ev_list, iter_raw) {
+    violations.push(
+      "Law F: each_vertex visited \{ev_list.length()} vertices, iter() yielded \{iter_raw.length()}; multisets differ",
+    )
+  }
+  // Law F cont'd: each_successor agrees with successors() for each vertex.
+  for v in iter_set {
+    let es_list : Array[Int] = []
+    G::each_successor(graph, v, fn(w) { es_list.push(w) })
+    let su_list : Array[Int] = G::successors(graph, v).collect()
+    if !multiset_eq(es_list, su_list) {
+      violations.push(
+        "Law F: each_successor(\{v}) visited \{es_list.length()} vertices, successors(\{v}) yielded \{su_list.length()}; multisets differ",
+      )
+    }
+  }
+  violations
+}
+
+///|
+/// Pick a small set of vertex IDs guaranteed not to be in `iter_raw`.
+/// Used for Law C negative consistency — we can't enumerate the complement
+/// of iter(), but we can spot-check sentinels that are guaranteed outside
+/// any finite vertex set we just observed.
+fn outside_candidates(iter_raw : Array[Int]) -> Array[Int] {
+  if iter_raw.length() == 0 {
+    // Any value works as "not in iter" when iter is empty.
+    return [0, 1, -1, @int.MAX_VALUE, @int.MIN_VALUE]
+  }
+  let mut lo = iter_raw[0]
+  let mut hi = iter_raw[0]
+  for v in iter_raw {
+    if v < lo {
+      lo = v
+    }
+    if v > hi {
+      hi = v
+    }
+  }
+  let candidates : Array[Int] = []
+  if hi < @int.MAX_VALUE {
+    candidates.push(hi + 1)
+  }
+  if lo > @int.MIN_VALUE {
+    candidates.push(lo - 1)
+  }
+  candidates.push(@int.MAX_VALUE)
+  candidates.push(@int.MIN_VALUE)
+  // Filter out any candidate that somehow appeared (edge case if iter
+  // contains both max and min): we want guaranteed-outside only.
+  let iter_set : @hashset.HashSet[Int] = @hashset.new()
+  for v in iter_raw {
+    iter_set.add(v)
+  }
+  let result : Array[Int] = []
+  for c in candidates {
+    if !iter_set.contains(c) {
+      result.push(c)
+    }
+  }
+  result
+}
+
+///|
+/// Check `Predecessors` conformance in addition to `DirectedGraph` laws.
+///
+/// Runs `check_conformance` first, then adds:
+///
+/// - **G.** Symmetry: `u ∈ predecessors(v) iff v ∈ successors(u)` for all
+///   vertices u, v in `iter()`.
+/// - **E'.** `predecessors(v)` contains no duplicates for each v.
+pub fn[G : DirectedGraph + Predecessors] check_predecessors_conformance(
+  graph : G,
+) -> Array[String] {
+  let violations = check_conformance(graph)
+  // Collect vertices once — no need to re-run iter duplicate check.
+  let iter_list : Array[Int] = G::iter(graph).collect()
+  // Build forward edge set: (u, v) for v ∈ successors(u).
+  let forward : @hashset.HashSet[(Int, Int)] = @hashset.new()
+  for u in iter_list {
+    for v in G::successors(graph, u) {
+      forward.add((u, v))
+    }
+  }
+  // Build backward edge set: (u, v) for u ∈ predecessors(v).
+  // Also checks Law E' (no duplicate predecessors per vertex).
+  let backward : @hashset.HashSet[(Int, Int)] = @hashset.new()
+  for v in iter_list {
+    let pred_seen : @hashset.HashSet[Int] = @hashset.new()
+    for u in Predecessors::predecessors(graph, v) {
+      if pred_seen.contains(u) {
+        violations.push(
+          "Law E': predecessors(\{v}) yielded duplicate vertex \{u}",
+        )
+      } else {
+        pred_seen.add(u)
+      }
+      backward.add((u, v))
+    }
+  }
+  // Law G: forward and backward edge sets must match.
+  for edge in forward {
+    if !backward.contains(edge) {
+      violations.push(
+        "Law G: \{edge.1} ∈ successors(\{edge.0}) but \{edge.0} ∉ predecessors(\{edge.1})",
+      )
+    }
+  }
+  for edge in backward {
+    if !forward.contains(edge) {
+      violations.push(
+        "Law G: \{edge.0} ∈ predecessors(\{edge.1}) but \{edge.1} ∉ successors(\{edge.0})",
+      )
+    }
+  }
+  violations
+}
+
+///|
+/// Multiset equality over Int arrays. O(n) via hash counting.
+fn multiset_eq(a : Array[Int], b : Array[Int]) -> Bool {
+  if a.length() != b.length() {
+    return false
+  }
+  let counts : @hashmap.HashMap[Int, Int] = @hashmap.new()
+  for x in a {
+    match counts.get(x) {
+      Some(n) => counts[x] = n + 1
+      None => counts[x] = 1
+    }
+  }
+  for x in b {
+    match counts.get(x) {
+      Some(n) => if n == 1 { counts.remove(x) } else { counts[x] = n - 1 }
+      None => return false
+    }
+  }
+  counts.length() == 0
+}

--- a/src/conformance_test.mbt
+++ b/src/conformance_test.mbt
@@ -4,6 +4,15 @@
 // violates exactly one property (where possible).
 
 ///|
+/// True if some violation message contains every substring in `parts`.
+/// Used to tie a test to a specific message (not just "some Law X appears
+/// anywhere") — combining e.g. `["Law B", "99"]` asserts that the Law B
+/// violation names the offending vertex.
+fn has_violation(violations : Array[String], parts : Array[String]) -> Bool {
+  violations.iter().any(fn(s) { parts.iter().all(fn(p) { s.contains(p) }) })
+}
+
+///|
 struct DupIter {}
 
 ///|
@@ -131,34 +140,31 @@ test "positive: self-loop conforms" {
 ///|
 test "negative: Law A — duplicate iter flagged" {
   let v = @alga.check_conformance(DupIter::{  })
-  assert_true(v.length() >= 1)
-  assert_true(v.iter().any(fn(s) { s.contains("Law A") }))
+  assert_true(has_violation(v, ["Law A"]))
 }
 
 ///|
 test "negative: Law B — dangling successor flagged" {
   let v = @alga.check_conformance(DanglingSucc::{  })
-  assert_true(v.iter().any(fn(s) { s.contains("Law B") }))
-  assert_true(v.iter().any(fn(s) { s.contains("99") }))
+  assert_true(has_violation(v, ["Law B", "99"]))
 }
 
 ///|
 test "negative: Law E — duplicate successor flagged" {
   let v = @alga.check_conformance(DupSucc::{  })
-  assert_true(v.iter().any(fn(s) { s.contains("Law E") }))
+  assert_true(has_violation(v, ["Law E"]))
 }
 
 ///|
 test "negative: Law D — vertex_count mismatch flagged" {
   let v = @alga.check_conformance(VertexCountLies::{  })
-  assert_true(v.iter().any(fn(s) { s.contains("Law D") }))
-  assert_true(v.iter().any(fn(s) { s.contains("7") }))
+  assert_true(has_violation(v, ["Law D", "7"]))
 }
 
 ///|
 test "negative: Law C — has_vertex lies flagged" {
   let v = @alga.check_conformance(HasVertexLies::{  })
-  assert_true(v.iter().any(fn(s) { s.contains("Law C") }))
+  assert_true(has_violation(v, ["Law C"]))
 }
 
 ///|
@@ -189,7 +195,7 @@ pub impl @alga.DirectedGraph for HasVertexLiesPositive with has_vertex(
 test "negative: Law C — has_vertex returns true for absent vertex flagged" {
   // has_vertex always returns true — must be flagged on synthetic outside values.
   let v = @alga.check_conformance(HasVertexLiesPositive::{  })
-  assert_true(v.iter().any(fn(s) { s.contains("Law C") && s.contains("true") }))
+  assert_true(has_violation(v, ["Law C", "true"]))
 }
 
 ///|
@@ -215,9 +221,7 @@ pub impl @alga.DirectedGraph for EachVertexWrong with each_vertex(_self, f) {
 ///|
 test "negative: Law F — each_vertex override disagrees with iter" {
   let v = @alga.check_conformance(EachVertexWrong::{  })
-  assert_true(
-    v.iter().any(fn(s) { s.contains("Law F") && s.contains("each_vertex") }),
-  )
+  assert_true(has_violation(v, ["Law F", "each_vertex"]))
 }
 
 ///|
@@ -250,9 +254,7 @@ pub impl @alga.DirectedGraph for EachSuccessorWrong with each_successor(
 ///|
 test "negative: Law F — each_successor override disagrees with successors" {
   let v = @alga.check_conformance(EachSuccessorWrong::{  })
-  assert_true(
-    v.iter().any(fn(s) { s.contains("Law F") && s.contains("each_successor") }),
-  )
+  assert_true(has_violation(v, ["Law F", "each_successor"]))
 }
 
 ///|
@@ -281,7 +283,7 @@ pub impl @alga.Predecessors for AsymmetricPred with predecessors(_self, _v) {
 ///|
 test "negative: Law G — asymmetric predecessors flagged" {
   let v = @alga.check_predecessors_conformance(AsymmetricPred::{  })
-  assert_true(v.iter().any(fn(s) { s.contains("Law G") }))
+  assert_true(has_violation(v, ["Law G"]))
 }
 
 ///|
@@ -313,5 +315,5 @@ pub impl @alga.Predecessors for DupPred with predecessors(_self, v) {
 ///|
 test "negative: Law E' — duplicate predecessor flagged" {
   let v = @alga.check_predecessors_conformance(DupPred::{  })
-  assert_true(v.iter().any(fn(s) { s.contains("Law E'") }))
+  assert_true(has_violation(v, ["Law E'"]))
 }

--- a/src/conformance_test.mbt
+++ b/src/conformance_test.mbt
@@ -1,0 +1,317 @@
+// Deliberately-broken DirectedGraph impls used to verify that
+// check_conformance flags each law violation. Each struct is minimal —
+// it only implements the two required methods, and the broken one
+// violates exactly one property (where possible).
+
+///|
+struct DupIter {}
+
+///|
+pub impl @alga.DirectedGraph for DupIter with iter(_self) {
+  [1, 1, 2].iter()
+}
+
+///|
+pub impl @alga.DirectedGraph for DupIter with successors(_self, _v) {
+  Iter::empty()
+}
+
+///|
+struct DanglingSucc {}
+
+///|
+pub impl @alga.DirectedGraph for DanglingSucc with iter(_self) {
+  [1, 2].iter()
+}
+
+///|
+pub impl @alga.DirectedGraph for DanglingSucc with successors(_self, v) {
+  if v == 1 {
+    [99].iter()
+  } else {
+    Iter::empty()
+  }
+}
+
+///|
+struct DupSucc {}
+
+///|
+pub impl @alga.DirectedGraph for DupSucc with iter(_self) {
+  [1, 2].iter()
+}
+
+///|
+pub impl @alga.DirectedGraph for DupSucc with successors(_self, v) {
+  if v == 1 {
+    [2, 2].iter()
+  } else {
+    Iter::empty()
+  }
+}
+
+///|
+struct VertexCountLies {}
+
+///|
+pub impl @alga.DirectedGraph for VertexCountLies with iter(_self) {
+  [1, 2, 3].iter()
+}
+
+///|
+pub impl @alga.DirectedGraph for VertexCountLies with successors(_self, _v) {
+  Iter::empty()
+}
+
+///|
+pub impl @alga.DirectedGraph for VertexCountLies with vertex_count(_self) {
+  7
+}
+
+///|
+struct HasVertexLies {}
+
+///|
+pub impl @alga.DirectedGraph for HasVertexLies with iter(_self) {
+  [1, 2].iter()
+}
+
+///|
+pub impl @alga.DirectedGraph for HasVertexLies with successors(_self, _v) {
+  Iter::empty()
+}
+
+///|
+pub impl @alga.DirectedGraph for HasVertexLies with has_vertex(_self, _v) {
+  false
+}
+
+///|
+test "positive: AdjacencyMap conforms" {
+  let g = @alga.AdjacencyMap::from_edges([(1, 2), (2, 3), (3, 1)])
+  assert_eq(@alga.check_conformance(g), [])
+}
+
+///|
+test "positive: AdjacencyMap with Predecessors conforms" {
+  let g = @alga.AdjacencyMap::from_edges([(1, 2), (2, 3), (3, 1), (1, 3)])
+  assert_eq(@alga.check_predecessors_conformance(g), [])
+}
+
+///|
+test "positive: DenseGraph conforms" {
+  let g = @alga.DenseGraph::from_edges(4, [(0, 1), (1, 2), (2, 0), (2, 3)])
+  assert_eq(@alga.check_predecessors_conformance(g), [])
+}
+
+///|
+test "positive: Reversed conforms" {
+  let g = @alga.AdjacencyMap::from_edges([(1, 2), (2, 3)])
+  assert_eq(@alga.check_predecessors_conformance(@alga.reversed(g)), [])
+}
+
+///|
+test "positive: empty graph conforms" {
+  let g : @alga.AdjacencyMap = @alga.AdjacencyMap::empty()
+  assert_eq(@alga.check_predecessors_conformance(g), [])
+}
+
+///|
+test "positive: single vertex conforms" {
+  let g = @alga.AdjacencyMap::vertex(42)
+  assert_eq(@alga.check_predecessors_conformance(g), [])
+}
+
+///|
+test "positive: self-loop conforms" {
+  let g = @alga.AdjacencyMap::from_edges([(1, 1)])
+  assert_eq(@alga.check_predecessors_conformance(g), [])
+}
+
+///|
+test "negative: Law A — duplicate iter flagged" {
+  let v = @alga.check_conformance(DupIter::{  })
+  assert_true(v.length() >= 1)
+  assert_true(v.iter().any(fn(s) { s.contains("Law A") }))
+}
+
+///|
+test "negative: Law B — dangling successor flagged" {
+  let v = @alga.check_conformance(DanglingSucc::{  })
+  assert_true(v.iter().any(fn(s) { s.contains("Law B") }))
+  assert_true(v.iter().any(fn(s) { s.contains("99") }))
+}
+
+///|
+test "negative: Law E — duplicate successor flagged" {
+  let v = @alga.check_conformance(DupSucc::{  })
+  assert_true(v.iter().any(fn(s) { s.contains("Law E") }))
+}
+
+///|
+test "negative: Law D — vertex_count mismatch flagged" {
+  let v = @alga.check_conformance(VertexCountLies::{  })
+  assert_true(v.iter().any(fn(s) { s.contains("Law D") }))
+  assert_true(v.iter().any(fn(s) { s.contains("7") }))
+}
+
+///|
+test "negative: Law C — has_vertex lies flagged" {
+  let v = @alga.check_conformance(HasVertexLies::{  })
+  assert_true(v.iter().any(fn(s) { s.contains("Law C") }))
+}
+
+///|
+struct HasVertexLiesPositive {}
+
+///|
+pub impl @alga.DirectedGraph for HasVertexLiesPositive with iter(_self) {
+  [1, 2].iter()
+}
+
+///|
+pub impl @alga.DirectedGraph for HasVertexLiesPositive with successors(
+  _self,
+  _v,
+) {
+  Iter::empty()
+}
+
+///|
+pub impl @alga.DirectedGraph for HasVertexLiesPositive with has_vertex(
+  _self,
+  _v,
+) {
+  true
+}
+
+///|
+test "negative: Law C — has_vertex returns true for absent vertex flagged" {
+  // has_vertex always returns true — must be flagged on synthetic outside values.
+  let v = @alga.check_conformance(HasVertexLiesPositive::{  })
+  assert_true(v.iter().any(fn(s) { s.contains("Law C") && s.contains("true") }))
+}
+
+///|
+struct EachVertexWrong {}
+
+///|
+pub impl @alga.DirectedGraph for EachVertexWrong with iter(_self) {
+  [1, 2, 3].iter()
+}
+
+///|
+pub impl @alga.DirectedGraph for EachVertexWrong with successors(_self, _v) {
+  Iter::empty()
+}
+
+///|
+pub impl @alga.DirectedGraph for EachVertexWrong with each_vertex(_self, f) {
+  // Intentionally drops vertex 3.
+  f(1)
+  f(2)
+}
+
+///|
+test "negative: Law F — each_vertex override disagrees with iter" {
+  let v = @alga.check_conformance(EachVertexWrong::{  })
+  assert_true(
+    v.iter().any(fn(s) { s.contains("Law F") && s.contains("each_vertex") }),
+  )
+}
+
+///|
+struct EachSuccessorWrong {}
+
+///|
+pub impl @alga.DirectedGraph for EachSuccessorWrong with iter(_self) {
+  [1, 2].iter()
+}
+
+///|
+pub impl @alga.DirectedGraph for EachSuccessorWrong with successors(_self, v) {
+  if v == 1 {
+    [2].iter()
+  } else {
+    Iter::empty()
+  }
+}
+
+///|
+pub impl @alga.DirectedGraph for EachSuccessorWrong with each_successor(
+  _self,
+  _v,
+  _f,
+) {
+  // Intentionally visits nothing even when successors(1) = [2].
+  ()
+}
+
+///|
+test "negative: Law F — each_successor override disagrees with successors" {
+  let v = @alga.check_conformance(EachSuccessorWrong::{  })
+  assert_true(
+    v.iter().any(fn(s) { s.contains("Law F") && s.contains("each_successor") }),
+  )
+}
+
+///|
+struct AsymmetricPred {}
+
+///|
+pub impl @alga.DirectedGraph for AsymmetricPred with iter(_self) {
+  [1, 2].iter()
+}
+
+///|
+pub impl @alga.DirectedGraph for AsymmetricPred with successors(_self, v) {
+  if v == 1 {
+    [2].iter()
+  } else {
+    Iter::empty()
+  }
+}
+
+///|
+pub impl @alga.Predecessors for AsymmetricPred with predecessors(_self, _v) {
+  // Always empty — breaks symmetry (2 has 1 as a real predecessor).
+  Iter::empty()
+}
+
+///|
+test "negative: Law G — asymmetric predecessors flagged" {
+  let v = @alga.check_predecessors_conformance(AsymmetricPred::{  })
+  assert_true(v.iter().any(fn(s) { s.contains("Law G") }))
+}
+
+///|
+struct DupPred {}
+
+///|
+pub impl @alga.DirectedGraph for DupPred with iter(_self) {
+  [1, 2].iter()
+}
+
+///|
+pub impl @alga.DirectedGraph for DupPred with successors(_self, v) {
+  if v == 1 {
+    [2].iter()
+  } else {
+    Iter::empty()
+  }
+}
+
+///|
+pub impl @alga.Predecessors for DupPred with predecessors(_self, v) {
+  if v == 2 {
+    [1, 1].iter()
+  } else {
+    Iter::empty()
+  }
+}
+
+///|
+test "negative: Law E' — duplicate predecessor flagged" {
+  let v = @alga.check_predecessors_conformance(DupPred::{  })
+  assert_true(v.iter().any(fn(s) { s.contains("Law E'") }))
+}

--- a/src/moon.pkg
+++ b/src/moon.pkg
@@ -3,6 +3,7 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/hashmap",
   "moonbitlang/core/hashset",
+  "moonbitlang/core/int",
   "moonbitlang/core/quickcheck" @coreqc,
   "moonbitlang/core/quickcheck/splitmix" @splitmix,
   "moonbitlang/quickcheck" @qc,

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -11,6 +11,10 @@ pub fn[G : DirectedGraph, Acc] bfs_fold(G, Int, Acc, (Acc, Int) -> (Acc, Bool)) 
 
 pub fn[G : DirectedGraph, Acc] bfs_fold_multi(G, Array[Int], Acc, (Acc, Int) -> (Acc, Bool)) -> Acc
 
+pub fn[G : DirectedGraph] check_conformance(G) -> Array[String]
+
+pub fn[G : DirectedGraph + Predecessors] check_predecessors_conformance(G) -> Array[String]
+
 pub fn[G : DirectedGraph] dfs_events(G) -> Iter[DfsEvent]
 
 pub fn[G : DirectedGraph, Acc] dfs_fold(G, Int, Acc, (Acc, Int) -> (Acc, Bool)) -> Acc


### PR DESCRIPTION
## Summary

Closes the TODO.md Active item: adopters can now verify their own `DirectedGraph` impl honors the trait contract at test time.

### New public API

- `check_conformance(g) -> Array[String]` — returns a list of violation messages for the `DirectedGraph` trait. Empty = conformant.
- `check_predecessors_conformance(g) -> Array[String]` — additionally verifies `Predecessors` symmetry and dedup.

Typical adopter usage:

```moonbit
test \"my graph conforms\" {
  let g = MyGraph::new(...)
  assert_eq(@alga.check_predecessors_conformance(g), [])
}
```

### Laws checked

| Law | Property |
|-----|----------|
| A | `iter()` yields each vertex exactly once |
| B | every `w ∈ successors(v)` is also in `iter()` |
| C | `has_vertex(v)` agrees with `iter()` for present vertices; sentinel spot-check for absent |
| D | `vertex_count() == iter().count()` |
| E | `successors(v)` contains no duplicates |
| F | `each_vertex` / `each_successor` defaults vs overrides agree |
| G | `u ∈ predecessors(v) iff v ∈ successors(u)` |
| E' | `predecessors(v)` contains no duplicates |

### Motivation

Codex's review on PR #31 flagged that algorithms silently misbehave on contract-violating impls. This kit can't prevent violations but catches them at test time. Deferred-for-later in TODO → promoted to Active → landed today.

### Review history

Codex reviewed twice:
1. First pass found 2 correctness bugs (dedup confusion between Laws A/D/F) + 1 gap (absent `has_vertex` not checked) + risk (missing negative tests). All fixed.
2. Second pass confirmed fixes, flagged one remaining spot-check limitation for Law C (documented in the module doc rather than engineered around — can't enumerate Int complement).

### Stats

- 6 files changed, +591 / -1
- `src/pkg.generated.mbti`: +4 lines, purely additive
- 272/272 tests pass (255 baseline + 17 new; 7 positive + 10 negative)

## Test plan

- [x] `moon check` clean
- [x] `moon test` — 272/272 pass
- [x] `moon info && moon fmt` clean; `.mbti` diff reviewed (additive only)
- [x] Codex review — no remaining correctness issues
- [ ] CI green on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)