### PR TITLE
docs(EXPERIMENT_REPORT): repoint CST Transform link

### DIFF
--- a/src/experiment/EXPERIMENT_REPORT.md
+++ b/src/experiment/EXPERIMENT_REPORT.md
@@ -7,7 +7,7 @@
 
 ## Motivation
 
-The [CST Transform REPORT](../../loom/cst-transform/REPORT.md) established that in wasm-gc:
+The [CST Transform REPORT](../../loom/docs/performance/2026-03-30-cst-traversal-tiers.md) established that in wasm-gc:
 
 - **Allocation is the dominant cost, not dispatch** (3–4x vs 1.25x)
 - **Indirection is not free** — tree pointer chasing costs more than flat array indexing


### PR DESCRIPTION
## Summary
The cst-transform/ research sandbox was deleted in [dowdiness/loom#104](https://github.com/dowdiness/loom/pull/104) once production CST traversal traits stabilized in `seam/`. The report itself was preserved verbatim at `loom/docs/performance/2026-03-30-cst-traversal-tiers.md`.

This PR updates the link in `src/experiment/EXPERIMENT_REPORT.md:10` from `../../loom/cst-transform/REPORT.md` (deleted) to the new location, so the citation resolves at canopy's next loom submodule pointer bump.

## Test plan
- [x] Link renders correctly in markdown preview
- [x] Target file confirmed present at `loom/docs/performance/2026-03-30-cst-traversal-tiers.md` (verbatim copy of original REPORT.md content)
- [x] Docs-only — no code paths affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)