### PR TITLE
feat: split DirectedGraph into VertexSet + Successors capability traits

### DIFF
--- a/docs/decisions-needed.md
+++ b/docs/decisions-needed.md
@@ -1,0 +1,41 @@
+# Decisions Needed
+
+Items requiring human judgment, surfaced by triage.
+
+## Active decisions
+
+### DenseGraph promotion — stabilize or keep experimental?
+
+**Source:** `docs/TODO.md` → "DenseGraph promotion"
+**Context:** `DenseGraph` is public, has full `DirectedGraph` + `Predecessors`
+impls, and benchmarks at 8–23× over `AdjacencyMap`. But
+`src/experiment/EXPERIMENT_REPORT.md` still treats it as experimental,
+and the "close out remaining experiment-only code" step is unresolved.
+Deciding to promote would cascade into GenCounter adoption and a
+specialized `DenseGraph::dfs_events`.
+**Blocks:** GenCounter for visited sets, specialized DenseGraph::dfs_events
+**Evidence:** Code is public and tested; interface is exported; experiment
+report wording is stale. No `docs/plans/*.md` plan exists.
+**Added:** 2026-06-22
+
+### NodeFiltered graph adaptor — implement or archive?
+
+**Source:** `docs/TODO.md` → "NodeFiltered graph adaptor"
+**Context:** A zero-copy `NodeFiltered[G]` adaptor implementing
+`DirectedGraph` for scope-restricted traversals. Has a source analysis
+in `docs/specs/2026-04-01-petgraph-analysis.md` but no implementation,
+no plan, and no adopter requesting it.
+**Blocks:** Nothing directly
+**Evidence:** Spec analysis exists; no code; no plan file; no open issue.
+**Added:** 2026-06-22
+
+### Traversal control flow — implement or archive?
+
+**Source:** `docs/TODO.md` → "Traversal control flow"
+**Context:** `dfs_fold`/`bfs_fold` callbacks return `(Acc, Bool)` for
+early termination. A `ControlFlow` enum would be cleaner. Already
+partially mitigated by `dfs_events` (Iter-based pull traversal). No
+implementation, no plan, no adopter requesting it.
+**Blocks:** Nothing directly
+**Evidence:** Spec analysis in petgraph doc; no code; no plan file.
+**Added:** 2026-06-22

--- a/moon.mod
+++ b/moon.mod
@@ -2,10 +2,6 @@ name = "dowdiness/alga"
 
 version = "0.3.1"
 
-options(
-  source: "src",
-)
-
 import {
   "moonbitlang/quickcheck@0.14.0",
 }
@@ -25,3 +21,7 @@ keywords = [
 ]
 
 description = "Algebraic graphs for MoonBit — directed graph trait and algorithm library inspired by Haskell's alga"
+
+options(
+  source: "src",
+)

--- a/src/adjacency_map.mbt
+++ b/src/adjacency_map.mbt
@@ -274,21 +274,11 @@ pub fn AdjacencyMap::successor_list(self : AdjacencyMap, v : Int) -> Array[Int] 
 }
 
 ///|
-pub fn AdjacencyMap::has_vertex(self : AdjacencyMap, v : Int) -> Bool {
-  self.adjacency.contains(v)
-}
-
-///|
 pub fn AdjacencyMap::has_edge(self : AdjacencyMap, u : Int, v : Int) -> Bool {
   match self.adjacency.get(u) {
     Some(s) => s.contains(v)
     None => false
   }
-}
-
-///|
-pub fn AdjacencyMap::vertex_count(self : AdjacencyMap) -> Int {
-  self.adjacency.length()
 }
 
 ///|
@@ -340,7 +330,7 @@ pub fn AdjacencyMap::remove_self_loops(self : AdjacencyMap) -> AdjacencyMap {
 ///|
 /// Show implementation for AdjacencyMap.
 /// Format: `AdjacencyMap({1: [2, 3], 2: []})`
-pub impl Show for AdjacencyMap with output(self, logger) {
+pub impl Show for AdjacencyMap with fn output(self, logger) {
   logger.write_string("AdjacencyMap({")
   let keys : Array[Int] = []
   for k, _ in self.adjacency {
@@ -373,7 +363,7 @@ pub impl Show for AdjacencyMap with output(self, logger) {
 ///|
 /// Debug implementation for AdjacencyMap.
 /// Produces structured Repr for inspect/debugging tools.
-pub impl Debug for AdjacencyMap with to_repr(self) {
+pub impl Debug for AdjacencyMap with fn to_repr(self) {
   let entries : Array[(@debug.Repr, @debug.Repr)] = []
   let keys : Array[Int] = []
   for k, _ in self.adjacency {
@@ -403,7 +393,7 @@ pub impl Debug for AdjacencyMap with to_repr(self) {
 /// Successor arrays are sorted before comparison since order may differ.
 // Only compares adjacency (forward edges). The predecessors map is derived —
 // if forward edges are equal, predecessors must be too (given correct construction).
-pub impl Eq for AdjacencyMap with equal(self, other) -> Bool {
+pub impl Eq for AdjacencyMap with fn equal(self, other) -> Bool {
   fn maps_equal(a : Map[Int, Array[Int]], b : Map[Int, Array[Int]]) -> Bool {
     if a.length() != b.length() {
       return false
@@ -435,17 +425,17 @@ pub impl Eq for AdjacencyMap with equal(self, other) -> Bool {
 
 ///|
 /// DirectedGraph trait implementation — delegates to the adjacency map.
-pub impl DirectedGraph for AdjacencyMap with vertex_count(self) {
+pub impl VertexSet for AdjacencyMap with fn vertex_count(self) {
   self.adjacency.length()
 }
 
 ///|
-pub impl DirectedGraph for AdjacencyMap with iter(self) {
+pub impl VertexSet for AdjacencyMap with fn iter(self) {
   self.adjacency.iter().map(fn(pair) { pair.0 })
 }
 
 ///|
-pub impl DirectedGraph for AdjacencyMap with successors(self, v) {
+pub impl Successors for AdjacencyMap with fn successors(self, v) {
   match self.adjacency.get(v) {
     Some(s) => s.iter()
     None => Iter::empty()
@@ -454,12 +444,15 @@ pub impl DirectedGraph for AdjacencyMap with successors(self, v) {
 
 ///|
 /// O(1) override — Map key lookup, bypasses the O(V) default scan.
-pub impl DirectedGraph for AdjacencyMap with has_vertex(self, v) {
+pub impl VertexSet for AdjacencyMap with fn has_vertex(self, v) {
   self.adjacency.contains(v)
 }
 
 ///|
-pub impl Predecessors for AdjacencyMap with predecessors(self, v) {
+pub impl DirectedGraph for AdjacencyMap
+
+///|
+pub impl Predecessors for AdjacencyMap with fn predecessors(self, v) {
   match self.predecessors.get(v) {
     Some(s) => s.iter()
     None => Iter::empty()

--- a/src/benchmark.mbt
+++ b/src/benchmark.mbt
@@ -333,18 +333,21 @@ priv struct BenchMinimalGraph {
 }
 
 ///|
-impl DirectedGraph for BenchMinimalGraph with iter(self) {
+impl VertexSet for BenchMinimalGraph with fn iter(self) {
   (0).until(self.edges.length())
 }
 
 ///|
-impl DirectedGraph for BenchMinimalGraph with successors(self, v) {
+impl Successors for BenchMinimalGraph with fn successors(self, v) {
   if v >= 0 && v < self.edges.length() {
     self.edges[v].iter()
   } else {
     Iter::empty()
   }
 }
+
+///|
+impl DirectedGraph for BenchMinimalGraph
 
 ///|
 fn build_minimal_chain(n : Int) -> BenchMinimalGraph {
@@ -361,20 +364,20 @@ fn build_minimal_chain(n : Int) -> BenchMinimalGraph {
 ///|
 test "bench/has_vertex/AdjacencyMap_1000" (b : @bench.T) {
   let g = build_chain(1000)
-  b.bench(fn() { b.keep(DirectedGraph::has_vertex(g, 500)) })
+  b.bench(fn() { b.keep(VertexSet::has_vertex(g, 500)) })
 }
 
 ///|
 test "bench/has_vertex/DenseGraph_1000" (b : @bench.T) {
   let am = build_chain(1000)
   let g = DenseGraph::from_adjacency_map(am)
-  b.bench(fn() { b.keep(DirectedGraph::has_vertex(g, 500)) })
+  b.bench(fn() { b.keep(VertexSet::has_vertex(g, 500)) })
 }
 
 ///|
 test "bench/has_vertex/default_1000" (b : @bench.T) {
   let g = build_minimal_chain(1000)
-  b.bench(fn() { b.keep(DirectedGraph::has_vertex(g, 500)) })
+  b.bench(fn() { b.keep(VertexSet::has_vertex(g, 500)) })
 }
 
 ///|
@@ -382,7 +385,7 @@ test "bench/has_vertex/default_1000" (b : @bench.T) {
 /// Compare against AdjacencyMap::vertex_count which is O(1) via Map::length().
 test "bench/vertex_count/default_1000" (b : @bench.T) {
   let g = build_minimal_chain(1000)
-  b.bench(fn() { b.keep(DirectedGraph::vertex_count(g)) })
+  b.bench(fn() { b.keep(VertexSet::vertex_count(g)) })
 }
 
 // --- condensation ---

--- a/src/bfs.mbt
+++ b/src/bfs.mbt
@@ -32,33 +32,13 @@
 /// before any vertex at distance d+1.
 ///
 /// Time: O(V + E) where V and E are the reachable vertices and edges.
-pub fn[G : DirectedGraph, Acc] bfs_fold(
+pub fn[G : Successors, Acc] bfs_fold(
   graph : G,
   start : Int,
   init : Acc,
   f : (Acc, Int) -> (Acc, Bool),
 ) -> Acc {
-  let visited : Map[Int, Bool] = Map([])
-  let queue : Array[Int] = [start]
-  visited[start] = true
-  let mut acc = init
-  let mut head = 0
-  while head < queue.length() {
-    let v = queue[head]
-    head = head + 1
-    let result = f(acc, v)
-    acc = result.0
-    if !result.1 {
-      break
-    }
-    G::each_successor(graph, v, fn(w) {
-      if visited.get(w) != Some(true) {
-        visited[w] = true
-        queue.push(w)
-      }
-    })
-  }
-  acc
+  graph.bfs_fold(start, init, f)
 }
 
 ///|

--- a/src/conformance.mbt
+++ b/src/conformance.mbt
@@ -154,16 +154,8 @@ fn outside_candidates(iter_set : @hashset.HashSet[Int]) -> Array[Int] {
     // Any value works as "not in iter" when iter is empty.
     return [0, 1, -1, @int.MAX_VALUE, @int.MIN_VALUE]
   }
-  let mut lo = @int.MAX_VALUE
-  let mut hi = @int.MIN_VALUE
-  for v in iter_set {
-    if v < lo {
-      lo = v
-    }
-    if v > hi {
-      hi = v
-    }
-  }
+  let lo = iter_set.fold(init=@int.MAX_VALUE, fn(acc, v) { @cmp.minimum(acc, v) })
+  let hi = iter_set.fold(init=@int.MIN_VALUE, fn(acc, v) { @cmp.maximum(acc, v) })
   let candidates : Array[Int] = []
   if hi < @int.MAX_VALUE {
     candidates.push(hi + 1)

--- a/src/conformance_test.mbt
+++ b/src/conformance_test.mbt
@@ -16,25 +16,28 @@ fn has_violation(violations : Array[String], parts : Array[String]) -> Bool {
 struct DupIter {}
 
 ///|
-pub impl @alga.DirectedGraph for DupIter with iter(_self) {
+pub impl @alga.VertexSet for DupIter with fn iter(_self) {
   [1, 1, 2].iter()
 }
 
 ///|
-pub impl @alga.DirectedGraph for DupIter with successors(_self, _v) {
+pub impl @alga.Successors for DupIter with fn successors(_self, _v) {
   Iter::empty()
 }
+
+///|
+pub impl @alga.DirectedGraph for DupIter
 
 ///|
 struct DanglingSucc {}
 
 ///|
-pub impl @alga.DirectedGraph for DanglingSucc with iter(_self) {
+pub impl @alga.VertexSet for DanglingSucc with fn iter(_self) {
   [1, 2].iter()
 }
 
 ///|
-pub impl @alga.DirectedGraph for DanglingSucc with successors(_self, v) {
+pub impl @alga.Successors for DanglingSucc with fn successors(_self, v) {
   if v == 1 {
     [99].iter()
   } else {
@@ -43,15 +46,18 @@ pub impl @alga.DirectedGraph for DanglingSucc with successors(_self, v) {
 }
 
 ///|
+pub impl @alga.DirectedGraph for DanglingSucc
+
+///|
 struct DupSucc {}
 
 ///|
-pub impl @alga.DirectedGraph for DupSucc with iter(_self) {
+pub impl @alga.VertexSet for DupSucc with fn iter(_self) {
   [1, 2].iter()
 }
 
 ///|
-pub impl @alga.DirectedGraph for DupSucc with successors(_self, v) {
+pub impl @alga.Successors for DupSucc with fn successors(_self, v) {
   if v == 1 {
     [2, 2].iter()
   } else {
@@ -60,38 +66,44 @@ pub impl @alga.DirectedGraph for DupSucc with successors(_self, v) {
 }
 
 ///|
+pub impl @alga.DirectedGraph for DupSucc
+
+///|
 struct VertexCountLies {}
 
 ///|
-pub impl @alga.DirectedGraph for VertexCountLies with iter(_self) {
+pub impl @alga.VertexSet for VertexCountLies with fn iter(_self) {
   [1, 2, 3].iter()
 }
 
 ///|
-pub impl @alga.DirectedGraph for VertexCountLies with successors(_self, _v) {
+pub impl @alga.Successors for VertexCountLies with fn successors(_self, _v) {
   Iter::empty()
 }
 
 ///|
-pub impl @alga.DirectedGraph for VertexCountLies with vertex_count(_self) {
+pub impl @alga.VertexSet for VertexCountLies with fn vertex_count(_self) {
   7
 }
+
+///|
+pub impl @alga.DirectedGraph for VertexCountLies
 
 ///|
 struct HasVertexLies {}
 
 ///|
-pub impl @alga.DirectedGraph for HasVertexLies with iter(_self) {
+pub impl @alga.VertexSet for HasVertexLies with fn iter(_self) {
   [1, 2].iter()
 }
 
 ///|
-pub impl @alga.DirectedGraph for HasVertexLies with successors(_self, _v) {
+pub impl @alga.Successors for HasVertexLies with fn successors(_self, _v) {
   Iter::empty()
 }
 
 ///|
-pub impl @alga.DirectedGraph for HasVertexLies with has_vertex(_self, _v) {
+pub impl @alga.VertexSet for HasVertexLies with fn has_vertex(_self, _v) {
   false
 }
 
@@ -171,12 +183,12 @@ test "negative: Law C — has_vertex lies flagged" {
 struct HasVertexLiesPositive {}
 
 ///|
-pub impl @alga.DirectedGraph for HasVertexLiesPositive with iter(_self) {
+pub impl @alga.VertexSet for HasVertexLiesPositive with fn iter(_self) {
   [1, 2].iter()
 }
 
 ///|
-pub impl @alga.DirectedGraph for HasVertexLiesPositive with successors(
+pub impl @alga.Successors for HasVertexLiesPositive with fn successors(
   _self,
   _v,
 ) {
@@ -184,12 +196,15 @@ pub impl @alga.DirectedGraph for HasVertexLiesPositive with successors(
 }
 
 ///|
-pub impl @alga.DirectedGraph for HasVertexLiesPositive with has_vertex(
-  _self,
-  _v,
-) {
+pub impl @alga.VertexSet for HasVertexLiesPositive with fn has_vertex(_self, _v) {
   true
 }
+
+///|
+pub impl @alga.DirectedGraph for HasVertexLiesPositive
+
+///|
+pub impl @alga.DirectedGraph for HasVertexLies
 
 ///|
 test "negative: Law C — has_vertex returns true for absent vertex flagged" {
@@ -202,21 +217,24 @@ test "negative: Law C — has_vertex returns true for absent vertex flagged" {
 struct EachVertexWrong {}
 
 ///|
-pub impl @alga.DirectedGraph for EachVertexWrong with iter(_self) {
+pub impl @alga.VertexSet for EachVertexWrong with fn iter(_self) {
   [1, 2, 3].iter()
 }
 
 ///|
-pub impl @alga.DirectedGraph for EachVertexWrong with successors(_self, _v) {
+pub impl @alga.Successors for EachVertexWrong with fn successors(_self, _v) {
   Iter::empty()
 }
 
 ///|
-pub impl @alga.DirectedGraph for EachVertexWrong with each_vertex(_self, f) {
+pub impl @alga.VertexSet for EachVertexWrong with fn each_vertex(_self, f) {
   // Intentionally drops vertex 3.
   f(1)
   f(2)
 }
+
+///|
+pub impl @alga.DirectedGraph for EachVertexWrong
 
 ///|
 test "negative: Law F — each_vertex override disagrees with iter" {
@@ -228,12 +246,12 @@ test "negative: Law F — each_vertex override disagrees with iter" {
 struct EachSuccessorWrong {}
 
 ///|
-pub impl @alga.DirectedGraph for EachSuccessorWrong with iter(_self) {
+pub impl @alga.VertexSet for EachSuccessorWrong with fn iter(_self) {
   [1, 2].iter()
 }
 
 ///|
-pub impl @alga.DirectedGraph for EachSuccessorWrong with successors(_self, v) {
+pub impl @alga.Successors for EachSuccessorWrong with fn successors(_self, v) {
   if v == 1 {
     [2].iter()
   } else {
@@ -242,7 +260,7 @@ pub impl @alga.DirectedGraph for EachSuccessorWrong with successors(_self, v) {
 }
 
 ///|
-pub impl @alga.DirectedGraph for EachSuccessorWrong with each_successor(
+pub impl @alga.Successors for EachSuccessorWrong with fn each_successor(
   _self,
   _v,
   _f,
@@ -250,6 +268,9 @@ pub impl @alga.DirectedGraph for EachSuccessorWrong with each_successor(
   // Intentionally visits nothing even when successors(1) = [2].
   ()
 }
+
+///|
+pub impl @alga.DirectedGraph for EachSuccessorWrong
 
 ///|
 test "negative: Law F — each_successor override disagrees with successors" {
@@ -261,12 +282,12 @@ test "negative: Law F — each_successor override disagrees with successors" {
 struct AsymmetricPred {}
 
 ///|
-pub impl @alga.DirectedGraph for AsymmetricPred with iter(_self) {
+pub impl @alga.VertexSet for AsymmetricPred with fn iter(_self) {
   [1, 2].iter()
 }
 
 ///|
-pub impl @alga.DirectedGraph for AsymmetricPred with successors(_self, v) {
+pub impl @alga.Successors for AsymmetricPred with fn successors(_self, v) {
   if v == 1 {
     [2].iter()
   } else {
@@ -275,10 +296,13 @@ pub impl @alga.DirectedGraph for AsymmetricPred with successors(_self, v) {
 }
 
 ///|
-pub impl @alga.Predecessors for AsymmetricPred with predecessors(_self, _v) {
+pub impl @alga.Predecessors for AsymmetricPred with fn predecessors(_self, _v) {
   // Always empty — breaks symmetry (2 has 1 as a real predecessor).
   Iter::empty()
 }
+
+///|
+pub impl @alga.DirectedGraph for AsymmetricPred
 
 ///|
 test "negative: Law G — asymmetric predecessors flagged" {
@@ -290,12 +314,12 @@ test "negative: Law G — asymmetric predecessors flagged" {
 struct DupPred {}
 
 ///|
-pub impl @alga.DirectedGraph for DupPred with iter(_self) {
+pub impl @alga.VertexSet for DupPred with fn iter(_self) {
   [1, 2].iter()
 }
 
 ///|
-pub impl @alga.DirectedGraph for DupPred with successors(_self, v) {
+pub impl @alga.Successors for DupPred with fn successors(_self, v) {
   if v == 1 {
     [2].iter()
   } else {
@@ -304,7 +328,7 @@ pub impl @alga.DirectedGraph for DupPred with successors(_self, v) {
 }
 
 ///|
-pub impl @alga.Predecessors for DupPred with predecessors(_self, v) {
+pub impl @alga.Predecessors for DupPred with fn predecessors(_self, v) {
   if v == 2 {
     [1, 1].iter()
   } else {
@@ -313,7 +337,61 @@ pub impl @alga.Predecessors for DupPred with predecessors(_self, v) {
 }
 
 ///|
+pub impl @alga.DirectedGraph for DupPred
+
+///|
 test "negative: Law E' — duplicate predecessor flagged" {
   let v = @alga.check_predecessors_conformance(DupPred::{  })
   assert_true(has_violation(v, ["Law E'"]))
+}
+
+///|
+/// A type that only implements `Successors` (no vertex enumeration).
+/// Proves that `reachable`, `outdegree`, `dfs_fold`, and `bfs_fold`
+/// work on successors-only graphs.
+struct SuccessorsOnly {
+  edges : Map[Int, Array[Int]]
+}
+
+///|
+pub impl @alga.Successors for SuccessorsOnly with fn successors(self, v) {
+  match self.edges.get(v) {
+    Some(s) => s.iter()
+    None => Iter::empty()
+  }
+}
+
+///|
+test "Successors-only: reachable works without VertexSet" {
+  // 0 → 1 → 2 → 3
+  let g = SuccessorsOnly::{ edges: Map([(0, [1]), (1, [2]), (2, [3]), (3, [])]) }
+  let r = @alga.reachable(g, 0)
+  @test.assert_eq(r.length(), 4)
+}
+
+///|
+test "Successors-only: dfs_fold works without VertexSet" {
+  let g = SuccessorsOnly::{ edges: Map([(0, [1, 2]), (1, [3]), (2, [3]), (3, [])]) }
+  let visited : Array[Int] = @alga.dfs_fold(g, 0, [], fn(arr : Array[Int], v) {
+    arr.push(v)
+    (arr, true)
+  })
+  @test.assert_eq(visited.length(), 4)
+}
+
+///|
+test "Successors-only: bfs_fold works without VertexSet" {
+  let g = SuccessorsOnly::{ edges: Map([(0, [1, 2]), (1, [3]), (2, [3]), (3, [])]) }
+  let visited : Array[Int] = @alga.bfs_fold(g, 0, [], fn(arr : Array[Int], v) {
+    arr.push(v)
+    (arr, true)
+  })
+  @test.assert_eq(visited.length(), 4)
+}
+
+///|
+test "Successors-only: outdegree works without VertexSet" {
+  let g = SuccessorsOnly::{ edges: Map([(0, [1, 2]), (1, [3]), (2, []), (3, [])]) }
+  @test.assert_eq(@alga.outdegree(g, 0), 2)
+  @test.assert_eq(@alga.outdegree(g, 3), 0)
 }

--- a/src/degree.mbt
+++ b/src/degree.mbt
@@ -23,11 +23,12 @@
 ///|
 /// Number of outgoing edges from vertex `v`.
 ///
-/// Returns 0 if `v` is not in the graph or has no successors.
+/// Returns 0 if `v` has no successors (including if `v` is not a vertex
+/// in the graph — `successors` returns `Iter::empty()` for absent vertices).
 /// Self-loops count: if v→v exists, it contributes 1 to outdegree.
 ///
 /// Time: O(degree(v)) — counts via `Iter::count` on successors.
-pub fn[G : DirectedGraph] outdegree(graph : G, v : Int) -> Int {
+pub fn[G : Successors] outdegree(graph : G, v : Int) -> Int {
   G::successors(graph, v).count()
 }
 

--- a/src/dense_graph.mbt
+++ b/src/dense_graph.mbt
@@ -103,7 +103,7 @@ pub fn DenseGraph::transpose(self : DenseGraph) -> DenseGraph {
 ///|
 /// Show implementation for DenseGraph.
 /// Format: `DenseGraph(3 vertices, [0 -> [1, 2], 1 -> [2]])`
-pub impl Show for DenseGraph with output(self, logger) {
+pub impl Show for DenseGraph with fn output(self, logger) {
   let n = self.successors.length()
   logger.write_string("DenseGraph(")
   logger.write_string(n.to_string())
@@ -133,7 +133,7 @@ pub impl Show for DenseGraph with output(self, logger) {
 ///|
 /// Debug implementation for DenseGraph.
 /// Produces structured Repr showing vertex count and edges.
-pub impl Debug for DenseGraph with to_repr(self) {
+pub impl Debug for DenseGraph with fn to_repr(self) {
   let fields : Map[String, @debug.Repr] = Map([])
   fields["vertex_count"] = @debug.to_repr(self.successors.length())
   let edges : Array[@debug.Repr] = []
@@ -147,18 +147,18 @@ pub impl Debug for DenseGraph with to_repr(self) {
 }
 
 ///|
-pub impl DirectedGraph for DenseGraph with iter(self) {
+pub impl VertexSet for DenseGraph with fn iter(self) {
   (0).until(self.successors.length())
 }
 
 ///|
 /// O(1) override — array length, bypasses the O(V) default iteration.
-pub impl DirectedGraph for DenseGraph with vertex_count(self) {
+pub impl VertexSet for DenseGraph with fn vertex_count(self) {
   self.successors.length()
 }
 
 ///|
-pub impl DirectedGraph for DenseGraph with successors(self, v) {
+pub impl Successors for DenseGraph with fn successors(self, v) {
   if v >= 0 && v < self.successors.length() {
     self.successors[v].iter()
   } else {
@@ -168,12 +168,82 @@ pub impl DirectedGraph for DenseGraph with successors(self, v) {
 
 ///|
 /// O(1) override — range check on dense 0..n-1 vertex IDs.
-pub impl DirectedGraph for DenseGraph with has_vertex(self, v) {
+pub impl VertexSet for DenseGraph with fn has_vertex(self, v) {
   v >= 0 && v < self.successors.length()
 }
 
 ///|
-pub impl Predecessors for DenseGraph with predecessors(self, v) {
+/// DFS fold with direct array access + `FixedArray[Bool]` visited set.
+/// Eliminates `Map[Int, Bool]` (O(log V) → O(1)) and `each_successor`
+/// callback dispatch (→ direct `Array[Int]` iteration).
+pub impl Successors for DenseGraph with fn dfs_fold(self, start, init, f) {
+  let n = self.successors.length()
+  if start < 0 || start >= n {
+    return init
+  }
+  let visited = FixedArray::make(n, false)
+  let stack : Array[Int] = [start]
+  let mut acc = init
+  while stack.length() > 0 {
+    let v = stack.unsafe_pop()
+    if visited[v] {
+      continue
+    }
+    visited[v] = true
+    let result = f(acc, v)
+    acc = result.0
+    if !result.1 {
+      break
+    }
+    let succs = self.successors[v]
+    for i in (succs.length() - 1)>=..0 {
+      let w = succs[i]
+      if !visited[w] {
+        stack.push(w)
+      }
+    }
+  }
+  acc
+}
+
+///|
+/// BFS fold with direct array access + `FixedArray[Bool]` visited set.
+/// Eliminates `Map[Int, Bool]` (O(log V) → O(1)) and `each_successor`
+/// callback dispatch (→ direct `Array[Int]` iteration).
+pub impl Successors for DenseGraph with fn bfs_fold(self, start, init, f) {
+  let n = self.successors.length()
+  if start < 0 || start >= n {
+    return init
+  }
+  let visited = FixedArray::make(n, false)
+  let queue : Array[Int] = [start]
+  visited[start] = true
+  let mut acc = init
+  let mut head = 0
+  while head < queue.length() {
+    let v = queue[head]
+    head = head + 1
+    let result = f(acc, v)
+    acc = result.0
+    if !result.1 {
+      break
+    }
+    let succs = self.successors[v]
+    for w in succs {
+      if !visited[w] {
+        visited[w] = true
+        queue.push(w)
+      }
+    }
+  }
+  acc
+}
+
+///|
+pub impl DirectedGraph for DenseGraph
+
+///|
+pub impl Predecessors for DenseGraph with fn predecessors(self, v) {
   if v >= 0 && v < self.predecessors.length() {
     self.predecessors[v].iter()
   } else {

--- a/src/dfs.mbt
+++ b/src/dfs.mbt
@@ -34,50 +34,18 @@
 /// When `should_continue` is `false`, traversal halts immediately.
 ///
 /// Time: O(V + E) where V and E are the reachable vertices and edges.
-pub fn[G : DirectedGraph, Acc] dfs_fold(
+pub fn[G : Successors, Acc] dfs_fold(
   graph : G,
   start : Int,
   init : Acc,
   f : (Acc, Int) -> (Acc, Bool),
 ) -> Acc {
-  let visited : Map[Int, Bool] = Map([])
-  let stack : Array[Int] = [start]
-  let mut acc = init
-  while stack.length() > 0 {
-    let v = stack.unsafe_pop()
-    if visited.get(v) == Some(true) {
-      continue
-    }
-    visited[v] = true
-    let result = f(acc, v)
-    acc = result.0
-    if !result.1 {
-      break
-    }
-    // Push successors directly, then reverse in place so first successor
-    // is on top of the stack. Avoids per-vertex temporary array allocation.
-    let mark = stack.length()
-    G::each_successor(graph, v, fn(w) {
-      if visited.get(w) != Some(true) {
-        stack.push(w)
-      }
-    })
-    let mut lo = mark
-    let mut hi = stack.length() - 1
-    while lo < hi {
-      let tmp = stack[lo]
-      stack[lo] = stack[hi]
-      stack[hi] = tmp
-      lo = lo + 1
-      hi = hi - 1
-    }
-  }
-  acc
+  graph.dfs_fold(start, init, f)
 }
 
 ///|
 /// All vertices reachable from `start`, in DFS pre-order.
-pub fn[G : DirectedGraph] reachable(graph : G, start : Int) -> Array[Int] {
+pub fn[G : Successors] reachable(graph : G, start : Int) -> Array[Int] {
   dfs_fold(graph, start, [], fn(arr, v) {
     arr.push(v)
     (arr, true)
@@ -173,14 +141,12 @@ pub fn[G : DirectedGraph, Acc] dfs_fold_multi(
   // so the main loop's visited-check + fold runs normally for each seed.
   // After seeding, clear visited so the main loop starts fresh.
   let seen : @hashset.HashSet[Int] = @hashset.HashSet([])
-  let mut i = starts.length() - 1
-  while i >= 0 {
+  for i in (starts.length() - 1)>=..0 {
     let s = starts[i]
     if !seen.contains(s) && G::has_vertex(graph, s) {
       seen.add(s)
       stack.push(s)
     }
-    i = i - 1
   }
   let mut acc = init
   while stack.length() > 0 {

--- a/src/dfs_test.mbt
+++ b/src/dfs_test.mbt
@@ -384,9 +384,9 @@ test "reversed successors are predecessors" {
   let g = @alga.AdjacencyMap::from_edges([(0, 1), (1, 2)])
   let rev = @alga.reversed(g)
   // Reversed successors of 2 = predecessors of 2 = [1]
-  @test.assert_eq(@alga.DirectedGraph::successors(rev, 2).collect(), [1])
+  @test.assert_eq(@alga.Successors::successors(rev, 2).collect(), [1])
   // Reversed successors of 0 = predecessors of 0 = []
-  @test.assert_eq(@alga.DirectedGraph::successors(rev, 0).collect(), [])
+  @test.assert_eq(@alga.Successors::successors(rev, 0).collect(), [])
 }
 
 ///|
@@ -400,16 +400,16 @@ test "reversed predecessors are successors" {
 test "reversed vertex count unchanged" {
   let g = @alga.AdjacencyMap::from_edges([(0, 1), (1, 2), (2, 3)])
   let rev = @alga.reversed(g)
-  @test.assert_eq(@alga.DirectedGraph::vertex_count(rev), 4)
+  @test.assert_eq(@alga.VertexSet::vertex_count(rev), 4)
 }
 
 ///|
 test "reversed has_vertex unchanged" {
   let g = @alga.AdjacencyMap::from_edges([(0, 1)])
   let rev = @alga.reversed(g)
-  assert_true(@alga.DirectedGraph::has_vertex(rev, 0))
-  assert_true(@alga.DirectedGraph::has_vertex(rev, 1))
-  assert_true(!@alga.DirectedGraph::has_vertex(rev, 99))
+  assert_true(@alga.VertexSet::has_vertex(rev, 0))
+  assert_true(@alga.VertexSet::has_vertex(rev, 1))
+  assert_true(!@alga.VertexSet::has_vertex(rev, 99))
 }
 
 ///|
@@ -417,9 +417,9 @@ test "reversed involution" {
   // reversed(reversed(g)) has same successors as g
   let g = @alga.AdjacencyMap::from_edges([(0, 1), (1, 2), (0, 2)])
   let rr = @alga.reversed(@alga.reversed(g))
-  for v in @alga.DirectedGraph::iter(g) {
-    let orig = @alga.DirectedGraph::successors(g, v).collect()
-    let double = @alga.DirectedGraph::successors(rr, v).collect()
+  for v in @alga.VertexSet::iter(g) {
+    let orig = @alga.Successors::successors(g, v).collect()
+    let double = @alga.Successors::successors(rr, v).collect()
     orig.sort()
     double.sort()
     @test.assert_eq(orig, double)
@@ -458,8 +458,8 @@ test "reversed works with reachable" {
 test "reversed DenseGraph" {
   let g = @alga.DenseGraph::from_edges(3, [(0, 1), (1, 2)])
   let rev = @alga.reversed(g)
-  @test.assert_eq(@alga.DirectedGraph::successors(rev, 2).collect(), [1])
-  @test.assert_eq(@alga.DirectedGraph::successors(rev, 0).collect(), [])
+  @test.assert_eq(@alga.Successors::successors(rev, 2).collect(), [1])
+  @test.assert_eq(@alga.Successors::successors(rev, 0).collect(), [])
 }
 
 ///|
@@ -474,7 +474,7 @@ test "reversed self loop" {
   let g = @alga.AdjacencyMap::from_edges([(1, 1)])
   let rev = @alga.reversed(g)
   // Self-loop stays a self-loop when reversed
-  @test.assert_eq(@alga.DirectedGraph::successors(rev, 1).collect(), [1])
+  @test.assert_eq(@alga.Successors::successors(rev, 1).collect(), [1])
 }
 
 ///|
@@ -492,7 +492,7 @@ test "predecessors on DenseGraph" {
 test "DenseGraph transpose regression" {
   let g = @alga.DenseGraph::from_edges(3, [(0, 1), (1, 2)])
   let t = g.transpose()
-  @test.assert_eq(@alga.DirectedGraph::successors(t, 2).collect(), [1])
+  @test.assert_eq(@alga.Successors::successors(t, 2).collect(), [1])
   @test.assert_eq(@alga.Predecessors::predecessors(t, 0).collect(), [1])
 }
 

--- a/src/experiment/dense_iteration.mbt
+++ b/src/experiment/dense_iteration.mbt
@@ -29,7 +29,7 @@ pub fn reachable_callback_no_temp(
     }
     visited[v] = gen
     result.push(v)
-    @alga.DirectedGraph::each_successor(graph, v, fn(w) {
+    @alga.Successors::each_successor(graph, v, fn(w) {
       if visited[w] != gen {
         stack.push(w)
       }
@@ -84,7 +84,7 @@ pub fn reachable_mark_rev(
     visited[v] = gen
     result.push(v)
     let mark = stack.length()
-    @alga.DirectedGraph::each_successor(graph, v, fn(w) {
+    @alga.Successors::each_successor(graph, v, fn(w) {
       if visited[w] != gen {
         stack.push(w)
       }
@@ -123,7 +123,7 @@ pub fn reachable_reuse_buf(
     while succs.length() > 0 {
       let _ = succs.unsafe_pop()
     }
-    @alga.DirectedGraph::each_successor(graph, v, fn(w) {
+    @alga.Successors::each_successor(graph, v, fn(w) {
       if visited[w] != gen {
         succs.push(w)
       }

--- a/src/experiment/pkg.generated.mbti
+++ b/src/experiment/pkg.generated.mbti
@@ -18,13 +18,13 @@ pub fn[G : @alga.DirectedGraph, Acc] bfs_fold_fixedarray(G, Int, Acc, (Acc, Int)
 
 pub fn[G : @alga.DirectedGraph, Acc] bfs_fold_gen(G, Int, Acc, (Acc, Int) -> (Acc, Bool), FixedArray[Int], Int) -> Acc
 
-pub fn[G : @alga.DirectedGraph, Acc] bfs_fold_hashset(G, Int, Acc, (Acc, Int) -> (Acc, Bool)) -> Acc
+pub fn[G : @alga.Successors, Acc] bfs_fold_hashset(G, Int, Acc, (Acc, Int) -> (Acc, Bool)) -> Acc
 
 pub fn[G : @alga.DirectedGraph, Acc] dfs_fold_array(G, Int, Acc, (Acc, Int) -> (Acc, Bool)) -> Acc
 
 pub fn[G : @alga.DirectedGraph, Acc] dfs_fold_fixedarray(G, Int, Acc, (Acc, Int) -> (Acc, Bool)) -> Acc
 
-pub fn[G : @alga.DirectedGraph, Acc] dfs_fold_hashset(G, Int, Acc, (Acc, Int) -> (Acc, Bool)) -> Acc
+pub fn[G : @alga.Successors, Acc] dfs_fold_hashset(G, Int, Acc, (Acc, Int) -> (Acc, Bool)) -> Acc
 
 pub fn[B] foldg_cps(@alga.Graph, B, (Int) -> B, (B, B) -> B, (B, B) -> B) -> B
 
@@ -48,7 +48,7 @@ pub fn[G : @alga.DirectedGraph] reachable_fixedarray(G, Int) -> Array[Int]
 
 pub fn[G : @alga.DirectedGraph] reachable_gen(G, Int, FixedArray[Int], Int) -> Array[Int]
 
-pub fn[G : @alga.DirectedGraph] reachable_hashset(G, Int) -> Array[Int]
+pub fn[G : @alga.Successors] reachable_hashset(G, Int) -> Array[Int]
 
 pub fn reachable_mark_rev(@alga.DenseGraph, Int, FixedArray[Int], Int) -> Array[Int]
 

--- a/src/experiment/visited_set.mbt
+++ b/src/experiment/visited_set.mbt
@@ -14,9 +14,9 @@
 // === Helpers ===
 
 ///|
-fn[G : @alga.DirectedGraph] max_vertex_id(graph : G) -> Int {
+fn[G : @alga.VertexSet] max_vertex_id(graph : G) -> Int {
   let mut max_id = 0
-  @alga.DirectedGraph::each_vertex(graph, fn(v) { if v > max_id { max_id = v } })
+  @alga.VertexSet::each_vertex(graph, fn(v) { if v > max_id { max_id = v } })
   max_id
 }
 
@@ -46,7 +46,7 @@ fn bitset_test(words : FixedArray[Int], v : Int) -> Bool {
 // ============================================================
 
 ///|
-pub fn[G : @alga.DirectedGraph, Acc] dfs_fold_hashset(
+pub fn[G : @alga.Successors, Acc] dfs_fold_hashset(
   graph : G,
   start : Int,
   init : Acc,
@@ -67,7 +67,7 @@ pub fn[G : @alga.DirectedGraph, Acc] dfs_fold_hashset(
       break
     }
     let succs : Array[Int] = []
-    @alga.DirectedGraph::each_successor(graph, v, fn(w) {
+    @alga.Successors::each_successor(graph, v, fn(w) {
       if !visited.contains(w) {
         succs.push(w)
       }
@@ -80,7 +80,7 @@ pub fn[G : @alga.DirectedGraph, Acc] dfs_fold_hashset(
 }
 
 ///|
-pub fn[G : @alga.DirectedGraph] reachable_hashset(
+pub fn[G : @alga.Successors] reachable_hashset(
   graph : G,
   start : Int,
 ) -> Array[Int] {
@@ -117,7 +117,7 @@ pub fn[G : @alga.DirectedGraph, Acc] dfs_fold_array(
       break
     }
     let succs : Array[Int] = []
-    @alga.DirectedGraph::each_successor(graph, v, fn(w) {
+    @alga.Successors::each_successor(graph, v, fn(w) {
       if !visited[w] {
         succs.push(w)
       }
@@ -145,7 +145,7 @@ pub fn[G : @alga.DirectedGraph] reachable_array(
 // ============================================================
 
 ///|
-pub fn[G : @alga.DirectedGraph, Acc] bfs_fold_hashset(
+pub fn[G : @alga.Successors, Acc] bfs_fold_hashset(
   graph : G,
   start : Int,
   init : Acc,
@@ -164,7 +164,7 @@ pub fn[G : @alga.DirectedGraph, Acc] bfs_fold_hashset(
     if !result.1 {
       break
     }
-    @alga.DirectedGraph::each_successor(graph, v, fn(w) {
+    @alga.Successors::each_successor(graph, v, fn(w) {
       if !visited.contains(w) {
         visited.add(w)
         queue.push(w)
@@ -199,7 +199,7 @@ pub fn[G : @alga.DirectedGraph, Acc] bfs_fold_array(
     if !result.1 {
       break
     }
-    @alga.DirectedGraph::each_successor(graph, v, fn(w) {
+    @alga.Successors::each_successor(graph, v, fn(w) {
       if !visited[w] {
         visited[w] = true
         queue.push(w)
@@ -216,9 +216,9 @@ pub fn[G : @alga.DirectedGraph, Acc] bfs_fold_array(
 ///|
 pub fn[G : @alga.DirectedGraph] toposort_hashset(graph : G) -> Array[Int]? {
   let in_degree : @hashmap.HashMap[Int, Int] = @hashmap.HashMap([])
-  @alga.DirectedGraph::each_vertex(graph, fn(v) { in_degree[v] = 0 })
-  @alga.DirectedGraph::each_vertex(graph, fn(v) {
-    @alga.DirectedGraph::each_successor(graph, v, fn(w) {
+  @alga.VertexSet::each_vertex(graph, fn(v) { in_degree[v] = 0 })
+  @alga.VertexSet::each_vertex(graph, fn(v) {
+    @alga.Successors::each_successor(graph, v, fn(w) {
       match in_degree.get(w) {
         Some(n) => in_degree[w] = n + 1
         None => in_degree[w] = 1
@@ -233,7 +233,7 @@ pub fn[G : @alga.DirectedGraph] toposort_hashset(graph : G) -> Array[Int]? {
     let v = queue[head]
     head = head + 1
     result.push(v)
-    @alga.DirectedGraph::each_successor(graph, v, fn(w) {
+    @alga.Successors::each_successor(graph, v, fn(w) {
       match in_degree.get(w) {
         Some(n) => {
           in_degree[w] = n - 1
@@ -245,7 +245,7 @@ pub fn[G : @alga.DirectedGraph] toposort_hashset(graph : G) -> Array[Int]? {
       }
     })
   }
-  let vc = @alga.DirectedGraph::vertex_count(graph)
+  let vc = @alga.VertexSet::vertex_count(graph)
   if result.length() == vc {
     Some(result)
   } else {
@@ -262,9 +262,9 @@ pub fn[G : @alga.DirectedGraph] toposort_array(graph : G) -> Array[Int]? {
   let max_id = max_vertex_id(graph)
   // -1 sentinel = "not a vertex"
   let in_degree = Array::make(max_id + 1, -1)
-  @alga.DirectedGraph::each_vertex(graph, fn(v) { in_degree[v] = 0 })
-  @alga.DirectedGraph::each_vertex(graph, fn(v) {
-    @alga.DirectedGraph::each_successor(graph, v, fn(w) {
+  @alga.VertexSet::each_vertex(graph, fn(v) { in_degree[v] = 0 })
+  @alga.VertexSet::each_vertex(graph, fn(v) {
+    @alga.Successors::each_successor(graph, v, fn(w) {
       in_degree[w] = in_degree[w] + 1
     })
   })
@@ -280,14 +280,14 @@ pub fn[G : @alga.DirectedGraph] toposort_array(graph : G) -> Array[Int]? {
     let v = queue[head]
     head = head + 1
     result.push(v)
-    @alga.DirectedGraph::each_successor(graph, v, fn(w) {
+    @alga.Successors::each_successor(graph, v, fn(w) {
       in_degree[w] = in_degree[w] - 1
       if in_degree[w] == 0 {
         queue.push(w)
       }
     })
   }
-  let vc = @alga.DirectedGraph::vertex_count(graph)
+  let vc = @alga.VertexSet::vertex_count(graph)
   if result.length() == vc {
     Some(result)
   } else {
@@ -313,7 +313,7 @@ pub fn[G : @alga.DirectedGraph] has_cycle_array(graph : G) -> Bool {
 pub fn scc_hashset(graph : @alga.AdjacencyMap) -> Array[Array[Int]] {
   let visited : @hashset.HashSet[Int] = @hashset.HashSet([])
   let finish_order : Array[Int] = []
-  @alga.DirectedGraph::each_vertex(graph, fn(root) {
+  @alga.VertexSet::each_vertex(graph, fn(root) {
     if visited.contains(root) {
       return
     }
@@ -352,7 +352,7 @@ pub fn scc_hashset(graph : @alga.AdjacencyMap) -> Array[Array[Int]] {
     while stack.length() > 0 {
       let v = stack.unsafe_pop()
       component.push(v)
-      @alga.DirectedGraph::each_successor(transposed, v, fn(w) {
+      @alga.Successors::each_successor(transposed, v, fn(w) {
         if !visited2.contains(w) {
           visited2.add(w)
           stack.push(w)
@@ -373,7 +373,7 @@ pub fn scc_array(graph : @alga.AdjacencyMap) -> Array[Array[Int]] {
   let max_id = max_vertex_id(graph)
   let visited = Array::make(max_id + 1, false)
   let finish_order : Array[Int] = []
-  @alga.DirectedGraph::each_vertex(graph, fn(root) {
+  @alga.VertexSet::each_vertex(graph, fn(root) {
     if visited[root] {
       return
     }
@@ -412,7 +412,7 @@ pub fn scc_array(graph : @alga.AdjacencyMap) -> Array[Array[Int]] {
     while stack.length() > 0 {
       let v = stack.unsafe_pop()
       component.push(v)
-      @alga.DirectedGraph::each_successor(transposed, v, fn(w) {
+      @alga.Successors::each_successor(transposed, v, fn(w) {
         if !visited2[w] {
           visited2[w] = true
           stack.push(w)
@@ -451,7 +451,7 @@ pub fn[G : @alga.DirectedGraph, Acc] dfs_fold_fixedarray(
       break
     }
     let succs : Array[Int] = []
-    @alga.DirectedGraph::each_successor(graph, v, fn(w) {
+    @alga.Successors::each_successor(graph, v, fn(w) {
       if !visited[w] {
         succs.push(w)
       }
@@ -495,7 +495,7 @@ pub fn[G : @alga.DirectedGraph] reachable_gen(
     visited[v] = gen
     result.push(v)
     let succs : Array[Int] = []
-    @alga.DirectedGraph::each_successor(graph, v, fn(w) {
+    @alga.Successors::each_successor(graph, v, fn(w) {
       if visited[w] != gen {
         succs.push(w)
       }
@@ -528,7 +528,7 @@ pub fn[G : @alga.DirectedGraph] reachable_bitset(
     bitset_set(words, v)
     result.push(v)
     let succs : Array[Int] = []
-    @alga.DirectedGraph::each_successor(graph, v, fn(w) {
+    @alga.Successors::each_successor(graph, v, fn(w) {
       if !bitset_test(words, w) {
         succs.push(w)
       }
@@ -565,7 +565,7 @@ pub fn[G : @alga.DirectedGraph, Acc] bfs_fold_fixedarray(
     if !result.1 {
       break
     }
-    @alga.DirectedGraph::each_successor(graph, v, fn(w) {
+    @alga.Successors::each_successor(graph, v, fn(w) {
       if !visited[w] {
         visited[w] = true
         queue.push(w)
@@ -600,7 +600,7 @@ pub fn[G : @alga.DirectedGraph, Acc] bfs_fold_gen(
     if !result.1 {
       break
     }
-    @alga.DirectedGraph::each_successor(graph, v, fn(w) {
+    @alga.Successors::each_successor(graph, v, fn(w) {
       if visited[w] != gen {
         visited[w] = gen
         queue.push(w)
@@ -635,7 +635,7 @@ pub fn[G : @alga.DirectedGraph, Acc] bfs_fold_bitset(
     if !result.1 {
       break
     }
-    @alga.DirectedGraph::each_successor(graph, v, fn(w) {
+    @alga.Successors::each_successor(graph, v, fn(w) {
       if !bitset_test(words, w) {
         bitset_set(words, w)
         queue.push(w)
@@ -654,7 +654,7 @@ pub fn scc_fixedarray(graph : @alga.AdjacencyMap) -> Array[Array[Int]] {
   let max_id = max_vertex_id(graph)
   let visited = FixedArray::make(max_id + 1, false)
   let finish_order : Array[Int] = []
-  @alga.DirectedGraph::each_vertex(graph, fn(root) {
+  @alga.VertexSet::each_vertex(graph, fn(root) {
     if visited[root] {
       return
     }
@@ -693,7 +693,7 @@ pub fn scc_fixedarray(graph : @alga.AdjacencyMap) -> Array[Array[Int]] {
     while stack.length() > 0 {
       let v = stack.unsafe_pop()
       component.push(v)
-      @alga.DirectedGraph::each_successor(transposed, v, fn(w) {
+      @alga.Successors::each_successor(transposed, v, fn(w) {
         if !visited2[w] {
           visited2[w] = true
           stack.push(w)
@@ -718,7 +718,7 @@ pub fn scc_gen(
   let gen1 = gen
   let gen2 = gen + 1
   let finish_order : Array[Int] = []
-  @alga.DirectedGraph::each_vertex(graph, fn(root) {
+  @alga.VertexSet::each_vertex(graph, fn(root) {
     if visited_buf[root] == gen1 {
       return
     }
@@ -756,7 +756,7 @@ pub fn scc_gen(
     while stack.length() > 0 {
       let v = stack.unsafe_pop()
       component.push(v)
-      @alga.DirectedGraph::each_successor(transposed, v, fn(w) {
+      @alga.Successors::each_successor(transposed, v, fn(w) {
         if visited_buf[w] != gen2 {
           visited_buf[w] = gen2
           stack.push(w)
@@ -778,7 +778,7 @@ pub fn scc_bitset(graph : @alga.AdjacencyMap) -> Array[Array[Int]] {
   let sz = bitset_size(max_id)
   let visited = FixedArray::make(sz, 0)
   let finish_order : Array[Int] = []
-  @alga.DirectedGraph::each_vertex(graph, fn(root) {
+  @alga.VertexSet::each_vertex(graph, fn(root) {
     if bitset_test(visited, root) {
       return
     }
@@ -817,7 +817,7 @@ pub fn scc_bitset(graph : @alga.AdjacencyMap) -> Array[Array[Int]] {
     while stack.length() > 0 {
       let v = stack.unsafe_pop()
       component.push(v)
-      @alga.DirectedGraph::each_successor(transposed, v, fn(w) {
+      @alga.Successors::each_successor(transposed, v, fn(w) {
         if !bitset_test(visited2, w) {
           bitset_set(visited2, w)
           stack.push(w)

--- a/src/experiment/visited_set_test.mbt
+++ b/src/experiment/visited_set_test.mbt
@@ -29,7 +29,10 @@ test "correctness/reachable/chain" {
   debug_inspect(sorted(reachable_fixedarray(g, 0)) == expected, content="true")
   debug_inspect(sorted(reachable_bitset(g, 0)) == expected, content="true")
   let visited = FixedArray::make(5, 0)
-  debug_inspect(sorted(reachable_gen(g, 0, visited, 1)) == expected, content="true")
+  debug_inspect(
+    sorted(reachable_gen(g, 0, visited, 1)) == expected,
+    content="true",
+  )
 }
 
 // === DFS reachable — diamond graph ===
@@ -48,7 +51,10 @@ test "correctness/reachable/diamond" {
   debug_inspect(sorted(reachable_fixedarray(g, 0)) == expected, content="true")
   debug_inspect(sorted(reachable_bitset(g, 0)) == expected, content="true")
   let visited = FixedArray::make(5, 0)
-  debug_inspect(sorted(reachable_gen(g, 0, visited, 1)) == expected, content="true")
+  debug_inspect(
+    sorted(reachable_gen(g, 0, visited, 1)) == expected,
+    content="true",
+  )
 }
 
 // === DFS reachable — disconnected graph ===
@@ -62,13 +68,19 @@ test "correctness/reachable/disconnected" {
   debug_inspect(sorted(reachable_fixedarray(g, 0)) == expected, content="true")
   debug_inspect(sorted(reachable_bitset(g, 0)) == expected, content="true")
   let visited = FixedArray::make(6, 0)
-  debug_inspect(sorted(reachable_gen(g, 0, visited, 1)) == expected, content="true")
+  debug_inspect(
+    sorted(reachable_gen(g, 0, visited, 1)) == expected,
+    content="true",
+  )
   // From vertex 3: should reach 3, 4, 5
   let expected3 = sorted(@alga.reachable(g, 3))
   debug_inspect(sorted(reachable_array(g, 3)) == expected3, content="true")
   debug_inspect(sorted(reachable_fixedarray(g, 3)) == expected3, content="true")
   debug_inspect(sorted(reachable_bitset(g, 3)) == expected3, content="true")
-  debug_inspect(sorted(reachable_gen(g, 3, visited, 2)) == expected3, content="true")
+  debug_inspect(
+    sorted(reachable_gen(g, 3, visited, 2)) == expected3,
+    content="true",
+  )
 }
 
 // === DFS reachable — single vertex ===
@@ -81,7 +93,10 @@ test "correctness/reachable/single" {
   debug_inspect(sorted(reachable_fixedarray(g, 42)) == expected, content="true")
   debug_inspect(sorted(reachable_bitset(g, 42)) == expected, content="true")
   let visited = FixedArray::make(43, 0)
-  debug_inspect(sorted(reachable_gen(g, 42, visited, 1)) == expected, content="true")
+  debug_inspect(
+    sorted(reachable_gen(g, 42, visited, 1)) == expected,
+    content="true",
+  )
 }
 
 // === DFS reachable — cycle ===
@@ -94,7 +109,10 @@ test "correctness/reachable/cycle" {
   debug_inspect(sorted(reachable_fixedarray(g, 0)) == expected, content="true")
   debug_inspect(sorted(reachable_bitset(g, 0)) == expected, content="true")
   let visited = FixedArray::make(4, 0)
-  debug_inspect(sorted(reachable_gen(g, 0, visited, 1)) == expected, content="true")
+  debug_inspect(
+    sorted(reachable_gen(g, 0, visited, 1)) == expected,
+    content="true",
+  )
 }
 
 // === Generation counter — reuse across multiple calls ===
@@ -122,7 +140,10 @@ test "correctness/bfs/chain" {
   let count_fn : (Int, Int) -> (Int, Bool) = fn(acc, _v) { (acc + 1, true) }
   let expected = @alga.bfs_fold(g, 0, 0, count_fn)
   debug_inspect(bfs_fold_array(g, 0, 0, count_fn) == expected, content="true")
-  debug_inspect(bfs_fold_fixedarray(g, 0, 0, count_fn) == expected, content="true")
+  debug_inspect(
+    bfs_fold_fixedarray(g, 0, 0, count_fn) == expected,
+    content="true",
+  )
   debug_inspect(bfs_fold_bitset(g, 0, 0, count_fn) == expected, content="true")
   let visited = FixedArray::make(4, 0)
   debug_inspect(
@@ -137,7 +158,10 @@ test "correctness/bfs/diamond" {
   let count_fn : (Int, Int) -> (Int, Bool) = fn(acc, _v) { (acc + 1, true) }
   let expected = @alga.bfs_fold(g, 0, 0, count_fn)
   debug_inspect(bfs_fold_array(g, 0, 0, count_fn) == expected, content="true")
-  debug_inspect(bfs_fold_fixedarray(g, 0, 0, count_fn) == expected, content="true")
+  debug_inspect(
+    bfs_fold_fixedarray(g, 0, 0, count_fn) == expected,
+    content="true",
+  )
   debug_inspect(bfs_fold_bitset(g, 0, 0, count_fn) == expected, content="true")
   let visited = FixedArray::make(4, 0)
   debug_inspect(
@@ -167,10 +191,16 @@ test "correctness/scc/dag" {
   let g = @alga.AdjacencyMap::from_edges([(0, 1), (1, 2), (2, 3)])
   let expected = sorted_components(g.scc())
   debug_inspect(sorted_components(scc_array(g)) == expected, content="true")
-  debug_inspect(sorted_components(scc_fixedarray(g)) == expected, content="true")
+  debug_inspect(
+    sorted_components(scc_fixedarray(g)) == expected,
+    content="true",
+  )
   debug_inspect(sorted_components(scc_bitset(g)) == expected, content="true")
   let visited = FixedArray::make(4, 0)
-  debug_inspect(sorted_components(scc_gen(g, visited, 1)) == expected, content="true")
+  debug_inspect(
+    sorted_components(scc_gen(g, visited, 1)) == expected,
+    content="true",
+  )
 }
 
 ///|
@@ -178,10 +208,16 @@ test "correctness/scc/single_cycle" {
   let g = @alga.AdjacencyMap::from_edges([(0, 1), (1, 2), (2, 0)])
   let expected = sorted_components(g.scc())
   debug_inspect(sorted_components(scc_array(g)) == expected, content="true")
-  debug_inspect(sorted_components(scc_fixedarray(g)) == expected, content="true")
+  debug_inspect(
+    sorted_components(scc_fixedarray(g)) == expected,
+    content="true",
+  )
   debug_inspect(sorted_components(scc_bitset(g)) == expected, content="true")
   let visited = FixedArray::make(3, 0)
-  debug_inspect(sorted_components(scc_gen(g, visited, 1)) == expected, content="true")
+  debug_inspect(
+    sorted_components(scc_gen(g, visited, 1)) == expected,
+    content="true",
+  )
 }
 
 ///|
@@ -197,10 +233,16 @@ test "correctness/scc/multiple_components" {
   ])
   let expected = sorted_components(g.scc())
   debug_inspect(sorted_components(scc_array(g)) == expected, content="true")
-  debug_inspect(sorted_components(scc_fixedarray(g)) == expected, content="true")
+  debug_inspect(
+    sorted_components(scc_fixedarray(g)) == expected,
+    content="true",
+  )
   debug_inspect(sorted_components(scc_bitset(g)) == expected, content="true")
   let visited = FixedArray::make(5, 0)
-  debug_inspect(sorted_components(scc_gen(g, visited, 1)) == expected, content="true")
+  debug_inspect(
+    sorted_components(scc_gen(g, visited, 1)) == expected,
+    content="true",
+  )
 }
 
 ///|
@@ -208,10 +250,16 @@ test "correctness/scc/self_loop" {
   let g = @alga.AdjacencyMap::from_edges([(0, 0), (0, 1)])
   let expected = sorted_components(g.scc())
   debug_inspect(sorted_components(scc_array(g)) == expected, content="true")
-  debug_inspect(sorted_components(scc_fixedarray(g)) == expected, content="true")
+  debug_inspect(
+    sorted_components(scc_fixedarray(g)) == expected,
+    content="true",
+  )
   debug_inspect(sorted_components(scc_bitset(g)) == expected, content="true")
   let visited = FixedArray::make(2, 0)
-  debug_inspect(sorted_components(scc_gen(g, visited, 1)) == expected, content="true")
+  debug_inspect(
+    sorted_components(scc_gen(g, visited, 1)) == expected,
+    content="true",
+  )
 }
 
 // === SCC — gen counter reuse ===
@@ -244,7 +292,10 @@ test "correctness/reachable/large_chain" {
   debug_inspect(sorted(reachable_fixedarray(g, 0)) == expected, content="true")
   debug_inspect(sorted(reachable_bitset(g, 0)) == expected, content="true")
   let visited = FixedArray::make(1000, 0)
-  debug_inspect(sorted(reachable_gen(g, 0, visited, 1)) == expected, content="true")
+  debug_inspect(
+    sorted(reachable_gen(g, 0, visited, 1)) == expected,
+    content="true",
+  )
 }
 
 ///|
@@ -259,10 +310,16 @@ test "correctness/scc/large_cycle" {
   debug_inspect(expected.length(), content="1")
   debug_inspect(expected[0].length(), content="100")
   debug_inspect(sorted_components(scc_array(g)) == expected, content="true")
-  debug_inspect(sorted_components(scc_fixedarray(g)) == expected, content="true")
+  debug_inspect(
+    sorted_components(scc_fixedarray(g)) == expected,
+    content="true",
+  )
   debug_inspect(sorted_components(scc_bitset(g)) == expected, content="true")
   let visited = FixedArray::make(100, 0)
-  debug_inspect(sorted_components(scc_gen(g, visited, 1)) == expected, content="true")
+  debug_inspect(
+    sorted_components(scc_gen(g, visited, 1)) == expected,
+    content="true",
+  )
 }
 
 // === Bitset edge case: vertex ID at word boundary (31, 32, 63, 64) ===

--- a/src/graph_expr.mbt
+++ b/src/graph_expr.mbt
@@ -332,7 +332,7 @@ pub fn Graph::circuit(vs : Array[Int]) -> Graph {
 ///|
 /// Show implementation for Graph.
 /// Format: expression tree structure, e.g. `Overlay(Vertex(1), Connect(Vertex(2), Vertex(3)))`
-pub impl Show for Graph with output(self, logger) {
+pub impl Show for Graph with fn output(self, logger) {
   match self {
     Empty => logger.write_string("Empty")
     Vertex(v) => {
@@ -360,7 +360,7 @@ pub impl Show for Graph with output(self, logger) {
 ///|
 /// Debug implementation for Graph.
 /// Produces structured Repr for inspect/debugging tools.
-pub impl Debug for Graph with to_repr(self) {
+pub impl Debug for Graph with fn to_repr(self) {
   match self {
     Empty => @debug.Repr::ctor("Empty", [])
     Vertex(v) => @debug.Repr::ctor("Vertex", [(None, @debug.to_repr(v))])
@@ -380,21 +380,21 @@ pub impl Debug for Graph with to_repr(self) {
 ///|
 /// Graph also implements GraphSym — it IS the free algebra.
 /// The constructors are the interpretation.
-pub impl GraphSym for Graph with empty() {
+pub impl GraphSym for Graph with fn empty() {
   Empty
 }
 
 ///|
-pub impl GraphSym for Graph with vertex(v) {
+pub impl GraphSym for Graph with fn vertex(v) {
   Vertex(v)
 }
 
 ///|
-pub impl GraphSym for Graph with overlay(a, b) {
+pub impl GraphSym for Graph with fn overlay(a, b) {
   Overlay(a, b)
 }
 
 ///|
-pub impl GraphSym for Graph with connect(a, b) {
+pub impl GraphSym for Graph with fn connect(a, b) {
   Connect(a, b)
 }

--- a/src/graph_expr_qc.mbt
+++ b/src/graph_expr_qc.mbt
@@ -3,7 +3,7 @@
 /// Generates random graph expressions with bounded depth.
 /// Uses small vertex IDs (0..size) to increase chance of structural overlap.
 /// Depth capped at 4 to keep expression trees manageable (max ~16 leaves).
-pub impl @coreqc.Arbitrary for Graph with arbitrary(size, rs) {
+pub impl @coreqc.Arbitrary for Graph with fn arbitrary(size, rs) {
   fn go(depth : Int, rs : @splitmix.RandomState) -> Graph {
     if depth <= 0 {
       // 2/3 Vertex, 1/3 Empty at leaves — biases toward non-trivial graphs
@@ -34,7 +34,7 @@ pub impl @coreqc.Arbitrary for Graph with arbitrary(size, rs) {
 /// 2. Weakened form (Connect→Overlay)
 /// 3. Collapse to Empty
 /// 4. Recursive shrinks inside each child (preserves constructor)
-pub impl @qc.Shrink for Graph with shrink(self) {
+pub impl @qc.Shrink for Graph with fn shrink(self) {
   match self {
     Empty => Iter::empty()
     Vertex(_) => [Empty].iter()
@@ -150,9 +150,9 @@ test "prop: reversed successors match predecessors" {
     fn(g : Graph) -> Bool {
       let am = g.to_adjacency_map()
       let rev = reversed(am)
-      for v in DirectedGraph::iter(am) {
+      for v in VertexSet::iter(am) {
         let preds = Predecessors::predecessors(am, v).collect()
-        let rev_succs = DirectedGraph::successors(rev, v).collect()
+        let rev_succs = Successors::successors(rev, v).collect()
         preds.sort()
         rev_succs.sort()
         if preds != rev_succs {

--- a/src/graph_expr_test.mbt
+++ b/src/graph_expr_test.mbt
@@ -162,7 +162,10 @@ test "Graph Show" {
 ///|
 test "DenseGraph Show" {
   let g = @alga.DenseGraph::from_edges(3, [(0, 1), (0, 2), (1, 2)])
-  debug_inspect(g, content="<DenseGraph: { vertex_count: 3, edges: [(0, 1), (0, 2), (1, 2)] }>")
+  debug_inspect(
+    g,
+    content="<DenseGraph: { vertex_count: 3, edges: [(0, 1), (0, 2), (1, 2)] }>",
+  )
   let empty = @alga.DenseGraph::from_edges(2, [])
   debug_inspect(empty, content="<DenseGraph: { vertex_count: 2, edges: [] }>")
 }

--- a/src/graph_sym.mbt
+++ b/src/graph_sym.mbt
@@ -43,30 +43,30 @@
 /// Andrey Mokhov, "Algebraic Graphs with Class" (Haskell Symposium, 2017)
 /// https://dl.acm.org/doi/10.1145/3122955.3122956
 pub(open) trait GraphSym {
-  empty() -> Self
-  vertex(Int) -> Self
-  overlay(Self, Self) -> Self
-  connect(Self, Self) -> Self
+  fn empty() -> Self
+  fn vertex(Int) -> Self
+  fn overlay(Self, Self) -> Self
+  fn connect(Self, Self) -> Self
 }
 
 ///|
 /// AdjacencyMap implements GraphSym by directly building the adjacency
 /// representation — no intermediate syntax tree needed.
-pub impl GraphSym for AdjacencyMap with empty() {
+pub impl GraphSym for AdjacencyMap with fn empty() {
   AdjacencyMap::empty()
 }
 
 ///|
-pub impl GraphSym for AdjacencyMap with vertex(v) {
+pub impl GraphSym for AdjacencyMap with fn vertex(v) {
   AdjacencyMap::vertex(v)
 }
 
 ///|
-pub impl GraphSym for AdjacencyMap with overlay(a, b) {
+pub impl GraphSym for AdjacencyMap with fn overlay(a, b) {
   a.overlay(b)
 }
 
 ///|
-pub impl GraphSym for AdjacencyMap with connect(a, b) {
+pub impl GraphSym for AdjacencyMap with fn connect(a, b) {
   a.connect(b)
 }

--- a/src/integration_wbtest.mbt
+++ b/src/integration_wbtest.mbt
@@ -7,18 +7,21 @@ struct ArrayGraph {
 }
 
 ///|
-impl DirectedGraph for ArrayGraph with iter(self) {
+impl VertexSet for ArrayGraph with fn iter(self) {
   (0).until(self.successors.length())
 }
 
 ///|
-impl DirectedGraph for ArrayGraph with successors(self, v) {
+impl Successors for ArrayGraph with fn successors(self, v) {
   if v >= 0 && v < self.successors.length() {
     self.successors[v].iter()
   } else {
     Iter::empty()
   }
 }
+
+///|
+impl DirectedGraph for ArrayGraph
 
 ///|
 test "external impl: reachable" {
@@ -90,22 +93,22 @@ test "default has_vertex works on ArrayGraph" {
   // This exercises the O(V) default from traits.mbt, proving
   // the default impl is dispatched when no override exists.
   let g = ArrayGraph::{ successors: [[1, 2], [2], [3], []] }
-  assert_true(DirectedGraph::has_vertex(g, 0))
-  assert_true(DirectedGraph::has_vertex(g, 3))
-  assert_true(!DirectedGraph::has_vertex(g, 4))
-  assert_true(!DirectedGraph::has_vertex(g, -1))
+  assert_true(VertexSet::has_vertex(g, 0))
+  assert_true(VertexSet::has_vertex(g, 3))
+  assert_true(!VertexSet::has_vertex(g, 4))
+  assert_true(!VertexSet::has_vertex(g, -1))
 }
 
 ///|
 test "has_vertex O(1) override on AdjacencyMap" {
   // AdjacencyMap provides an O(1) override (Map::contains).
-  // Calling through DirectedGraph:: verifies the trait impl is
+  // Calling through VertexSet:: verifies the trait impl is
   // dispatched, not just the standalone AdjacencyMap::has_vertex.
   let g = AdjacencyMap::from_edges([(0, 1), (1, 2)])
-  assert_true(DirectedGraph::has_vertex(g, 0))
-  assert_true(DirectedGraph::has_vertex(g, 2))
-  assert_true(!DirectedGraph::has_vertex(g, 3))
-  assert_true(!DirectedGraph::has_vertex(g, -1))
+  assert_true(VertexSet::has_vertex(g, 0))
+  assert_true(VertexSet::has_vertex(g, 2))
+  assert_true(!VertexSet::has_vertex(g, 3))
+  assert_true(!VertexSet::has_vertex(g, -1))
 }
 
 ///|
@@ -114,8 +117,8 @@ test "has_vertex O(1) override on DenseGraph" {
   // Vertex 3 is out of range for a 3-vertex graph (valid: 0, 1, 2).
   // Negative IDs are always invalid.
   let g = DenseGraph::from_edges(3, [(0, 1), (1, 2)])
-  assert_true(DirectedGraph::has_vertex(g, 0))
-  assert_true(DirectedGraph::has_vertex(g, 2))
-  assert_true(!DirectedGraph::has_vertex(g, 3))
-  assert_true(!DirectedGraph::has_vertex(g, -1))
+  assert_true(VertexSet::has_vertex(g, 0))
+  assert_true(VertexSet::has_vertex(g, 2))
+  assert_true(!VertexSet::has_vertex(g, 3))
+  assert_true(!VertexSet::has_vertex(g, -1))
 }

--- a/src/moon.pkg
+++ b/src/moon.pkg
@@ -5,7 +5,7 @@ import {
   "moonbitlang/core/hashset",
   "moonbitlang/core/int",
   "moonbitlang/core/quickcheck" @coreqc,
-  "moonbitlang/core/quickcheck/splitmix" @splitmix,
+  "moonbitlang/core/quickcheck/splitmix",
   "moonbitlang/core/test",
   "moonbitlang/quickcheck" @qc,
 }

--- a/src/pkg.generated.mbti
+++ b/src/pkg.generated.mbti
@@ -9,7 +9,7 @@ import {
 }
 
 // Values
-pub fn[G : DirectedGraph, Acc] bfs_fold(G, Int, Acc, (Acc, Int) -> (Acc, Bool)) -> Acc
+pub fn[G : Successors, Acc] bfs_fold(G, Int, Acc, (Acc, Int) -> (Acc, Bool)) -> Acc
 
 pub fn[G : DirectedGraph, Acc] bfs_fold_multi(G, Array[Int], Acc, (Acc, Int) -> (Acc, Bool)) -> Acc
 
@@ -19,7 +19,7 @@ pub fn[G : DirectedGraph + Predecessors] check_predecessors_conformance(G) -> Ar
 
 pub fn[G : DirectedGraph] dfs_events(G) -> Iter[DfsEvent]
 
-pub fn[G : DirectedGraph, Acc] dfs_fold(G, Int, Acc, (Acc, Int) -> (Acc, Bool)) -> Acc
+pub fn[G : Successors, Acc] dfs_fold(G, Int, Acc, (Acc, Int) -> (Acc, Bool)) -> Acc
 
 pub fn[G : DirectedGraph, Acc] dfs_fold_multi(G, Array[Int], Acc, (Acc, Int) -> (Acc, Bool)) -> Acc
 
@@ -37,9 +37,9 @@ pub fn[G : DirectedGraph] is_reachable(G, Int, Int) -> Bool
 
 pub fn[G : DirectedGraph + Predecessors] kosaraju_scc(G) -> Array[Array[Int]]
 
-pub fn[G : DirectedGraph] outdegree(G, Int) -> Int
+pub fn[G : Successors] outdegree(G, Int) -> Int
 
-pub fn[G : DirectedGraph] reachable(G, Int) -> Array[Int]
+pub fn[G : Successors] reachable(G, Int) -> Array[Int]
 
 pub fn[G : DirectedGraph] reachable_multi(G, Array[Int]) -> Array[Int]
 
@@ -72,18 +72,18 @@ pub fn AdjacencyMap::edge_list(Self) -> Array[(Int, Int)]
 pub fn AdjacencyMap::empty() -> Self
 pub fn AdjacencyMap::from_edges(Array[(Int, Int)]) -> Self
 pub fn AdjacencyMap::has_edge(Self, Int, Int) -> Bool
-pub fn AdjacencyMap::has_vertex(Self, Int) -> Bool
 pub fn AdjacencyMap::overlay(Self, Self) -> Self
 pub fn AdjacencyMap::remove_self_loops(Self) -> Self
 pub fn AdjacencyMap::scc(Self) -> Array[Array[Int]]
 pub fn AdjacencyMap::successor_list(Self, Int) -> Array[Int]
 pub fn AdjacencyMap::transpose(Self) -> Self
 pub fn AdjacencyMap::vertex(Int) -> Self
-pub fn AdjacencyMap::vertex_count(Self) -> Int
 pub fn AdjacencyMap::vertex_list(Self) -> Array[Int]
 pub impl DirectedGraph for AdjacencyMap
 pub impl GraphSym for AdjacencyMap
 pub impl Predecessors for AdjacencyMap
+pub impl Successors for AdjacencyMap
+pub impl VertexSet for AdjacencyMap
 pub impl Eq for AdjacencyMap
 pub impl Show for AdjacencyMap
 pub impl @debug.Debug for AdjacencyMap
@@ -101,6 +101,8 @@ pub fn DenseGraph::toposort(Self) -> Array[Int]?
 pub fn DenseGraph::transpose(Self) -> Self
 pub impl DirectedGraph for DenseGraph
 pub impl Predecessors for DenseGraph
+pub impl Successors for DenseGraph
+pub impl VertexSet for DenseGraph
 pub impl Show for DenseGraph
 pub impl @debug.Debug for DenseGraph
 
@@ -138,19 +140,15 @@ pub impl @shrink.Shrink for Graph
 pub struct Reversed[G] {
   graph : G
 }
-pub impl[G : DirectedGraph + Predecessors] DirectedGraph for Reversed[G]
-pub impl[G : DirectedGraph] Predecessors for Reversed[G]
+pub impl[G : VertexSet + Predecessors] DirectedGraph for Reversed[G]
+pub impl[G : Successors] Predecessors for Reversed[G]
+pub impl[G : Predecessors] Successors for Reversed[G]
+pub impl[G : VertexSet] VertexSet for Reversed[G]
 
 // Type aliases
 
 // Traits
-pub(open) trait DirectedGraph {
-  fn iter(Self) -> Iter[Int]
-  fn successors(Self, Int) -> Iter[Int]
-  fn each_vertex(Self, (Int) -> Unit) -> Unit = _
-  fn each_successor(Self, Int, (Int) -> Unit) -> Unit = _
-  fn vertex_count(Self) -> Int = _
-  fn has_vertex(Self, Int) -> Bool = _
+pub(open) trait DirectedGraph : VertexSet + Successors {
 }
 
 pub(open) trait GraphSym {
@@ -162,5 +160,19 @@ pub(open) trait GraphSym {
 
 pub(open) trait Predecessors {
   fn predecessors(Self, Int) -> Iter[Int]
+}
+
+pub(open) trait Successors {
+  fn successors(Self, Int) -> Iter[Int]
+  fn[Acc] dfs_fold(Self, Int, Acc, (Acc, Int) -> (Acc, Bool)) -> Acc = _
+  fn[Acc] bfs_fold(Self, Int, Acc, (Acc, Int) -> (Acc, Bool)) -> Acc = _
+  fn each_successor(Self, Int, (Int) -> Unit) -> Unit = _
+}
+
+pub(open) trait VertexSet {
+  fn iter(Self) -> Iter[Int]
+  fn each_vertex(Self, (Int) -> Unit) -> Unit = _
+  fn vertex_count(Self) -> Int = _
+  fn has_vertex(Self, Int) -> Bool = _
 }
 

--- a/src/reversed.mbt
+++ b/src/reversed.mbt
@@ -1,9 +1,16 @@
 ///|
 /// # Reversed — zero-cost reverse-direction graph view
 ///
-/// Wraps any graph that implements `DirectedGraph + Predecessors` and
-/// swaps the direction of all edge queries. `successors` on the reversed
-/// graph returns `predecessors` on the original, and vice versa.
+/// Wraps any graph and swaps the direction of all edge queries.
+/// `successors` on the reversed graph returns `predecessors` on the
+/// original, and vice versa.
+///
+/// ## Capabilities provided
+///
+/// - `VertexSet for Reversed[G]` when `G : VertexSet`
+/// - `Successors for Reversed[G]` when `G : Predecessors`
+/// - `Predecessors for Reversed[G]` when `G : Successors`
+/// - `DirectedGraph for Reversed[G]` when `G : VertexSet + Predecessors`
 ///
 /// ## Properties
 ///
@@ -22,14 +29,22 @@ pub fn[G] reversed(graph : G) -> Reversed[G] {
 }
 
 ///|
-pub impl[G : DirectedGraph + Predecessors] DirectedGraph for Reversed[G] with iter(
-  self,
-) {
+pub impl[G : VertexSet] VertexSet for Reversed[G] with fn iter(self) {
   G::iter(self.graph)
 }
 
 ///|
-pub impl[G : DirectedGraph + Predecessors] DirectedGraph for Reversed[G] with successors(
+pub impl[G : VertexSet] VertexSet for Reversed[G] with fn has_vertex(self, v) {
+  G::has_vertex(self.graph, v)
+}
+
+///|
+pub impl[G : VertexSet] VertexSet for Reversed[G] with fn vertex_count(self) {
+  G::vertex_count(self.graph)
+}
+
+///|
+pub impl[G : Predecessors] Successors for Reversed[G] with fn successors(
   self,
   v,
 ) {
@@ -37,22 +52,10 @@ pub impl[G : DirectedGraph + Predecessors] DirectedGraph for Reversed[G] with su
 }
 
 ///|
-pub impl[G : DirectedGraph + Predecessors] DirectedGraph for Reversed[G] with has_vertex(
-  self,
-  v,
-) {
-  G::has_vertex(self.graph, v)
-}
+pub impl[G : VertexSet + Predecessors] DirectedGraph for Reversed[G]
 
 ///|
-pub impl[G : DirectedGraph + Predecessors] DirectedGraph for Reversed[G] with vertex_count(
-  self,
-) {
-  G::vertex_count(self.graph)
-}
-
-///|
-pub impl[G : DirectedGraph] Predecessors for Reversed[G] with predecessors(
+pub impl[G : Successors] Predecessors for Reversed[G] with fn predecessors(
   self,
   v,
 ) {

--- a/src/traits.mbt
+++ b/src/traits.mbt
@@ -1,10 +1,14 @@
 ///|
-/// # DirectedGraph — the observation layer
+/// # Observation layer — capability traits
 ///
-/// This trait defines the minimal interface for observing a directed graph.
-/// Implement `iter` and `successors` to get every algorithm in the library
-/// for free. `each_vertex`, `each_successor`, `vertex_count`, and `has_vertex`
-/// all have defaults derived from the two required methods.
+/// The observation layer is split into two fine-grained capability traits
+/// so that types that can follow edges but cannot enumerate all vertices
+/// (implicit graphs, pure functions, infinite streams) can still run
+/// local reachability and BFS/DFS from a known start.
+///
+/// - `VertexSet` — vertex enumeration + membership
+/// - `Successors` — edge traversal
+/// - `DirectedGraph` — convenience alias: `VertexSet + Successors`
 ///
 /// ## Contract
 ///
@@ -32,59 +36,186 @@
 /// for zero-cost reverse traversal. `AdjacencyMap` and `DenseGraph` both
 /// implement `Predecessors` via bidirectional adjacency storage.
 ///
-/// ## Example: minimal implementation (2 methods)
+/// ## Example: minimal implementation
 ///
+/// For types that can enumerate vertices AND follow edges:
 /// ```
 /// struct MyGraph { edges : Array[Array[Int]] }
 ///
-/// impl DirectedGraph for MyGraph with iter(self) {
+/// impl VertexSet for MyGraph with iter(self) {
 ///   (0).until(self.edges.length())
 /// }
-/// impl DirectedGraph for MyGraph with successors(self, v) {
+/// impl Successors for MyGraph with successors(self, v) {
 ///   self.edges[v].iter()
 /// }
-/// // vertex_count, has_vertex, each_vertex, each_successor all work via defaults.
+/// impl DirectedGraph for MyGraph
+/// // vertex_count, has_vertex, each_vertex, each_successor,
+/// // dfs_fold, bfs_fold all work via defaults.
 /// ```
-pub(open) trait DirectedGraph {
-  iter(Self) -> Iter[Int]
-  successors(Self, Int) -> Iter[Int]
-  each_vertex(Self, (Int) -> Unit) -> Unit = _
-  each_successor(Self, Int, (Int) -> Unit) -> Unit = _
-  vertex_count(Self) -> Int = _
-  has_vertex(Self, Int) -> Bool = _
+///
+/// For types that can only follow edges (no vertex enumeration):
+/// ```
+/// impl Successors for ImplicitGraph with successors(self, v) {
+///   f(v)  // compute successors from a function
+/// }
+/// // reachable, dfs_fold, bfs_fold, outdegree all work.
+/// ```
+
+// ============================================================
+// VertexSet — enumeration and membership
+// ============================================================
+
+///|
+/// Types that can enumerate their vertices.
+///
+/// Required method: `iter() -> Iter[Int]`.
+/// All others have O(V) defaults derived from `iter`.
+pub(open) trait VertexSet {
+  fn iter(Self) -> Iter[Int]
+  fn each_vertex(Self, (Int) -> Unit) -> Unit = _
+  fn vertex_count(Self) -> Int = _
+  fn has_vertex(Self, Int) -> Bool = _
 }
 
 ///|
 /// Default each_vertex: delegates to `Iter::each`.
-/// Uses trait-qualified `DirectedGraph::iter(self)` to guarantee correct dispatch.
-impl DirectedGraph with each_vertex(self, f) {
-  DirectedGraph::iter(self).each(f)
-}
-
-///|
-/// Default each_successor: delegates to `Iter::each`.
-impl DirectedGraph with each_successor(self, v, f) {
-  DirectedGraph::successors(self, v).each(f)
+impl VertexSet with fn each_vertex(self, f) {
+  VertexSet::iter(self).each(f)
 }
 
 ///|
 /// Default vertex_count: O(V) — counts via `Iter::count`.
 /// Override for O(1) if your type tracks vertex count directly.
-impl DirectedGraph with vertex_count(self) {
-  DirectedGraph::iter(self).count()
+impl VertexSet with fn vertex_count(self) {
+  VertexSet::iter(self).count()
 }
 
 ///|
 /// Default has_vertex: uses `Iter::contains` which short-circuits on match.
 /// O(1) best case, O(V) worst case. Override for O(1) if your type
 /// supports constant-time membership.
-impl DirectedGraph with has_vertex(self, v) {
-  DirectedGraph::iter(self).contains(v)
+impl VertexSet with fn has_vertex(self, v) {
+  VertexSet::iter(self).contains(v)
+}
+
+// ============================================================
+// Successors — edge traversal
+// ============================================================
+
+///|
+/// Types that can follow edges from a vertex.
+///
+/// Required method: `successors(v) -> Iter[Int]`.
+/// `dfs_fold` and `bfs_fold` have defaults using `each_successor`
+/// with a `Map[Int, Bool]` visited set; override for faster
+/// visited-set tracking (e.g. `FixedArray[Bool]` for dense IDs).
+pub(open) trait Successors {
+  fn successors(Self, Int) -> Iter[Int]
+  fn[Acc] dfs_fold(Self, Int, Acc, (Acc, Int) -> (Acc, Bool)) -> Acc = _
+  fn[Acc] bfs_fold(Self, Int, Acc, (Acc, Int) -> (Acc, Bool)) -> Acc = _
+  fn each_successor(Self, Int, (Int) -> Unit) -> Unit = _
 }
 
 ///|
-/// # Predecessors — reverse-direction observation capability
+/// Default each_successor: delegates to `Iter::each`.
+impl Successors with fn each_successor(self, v, f) {
+  Successors::successors(self, v).each(f)
+}
+
+///|
+/// Default dfs_fold: DFS with `Map[Int, Bool]` visited set.
+/// Stack-safe iterative implementation. Override for types that can
+/// provide faster visited-set tracking (e.g. `FixedArray[Bool]` for dense IDs).
 ///
+/// Note: `Successors`-only traversal starts from a known vertex.
+/// The default does not validate that `start` exists in any vertex set —
+/// callers that need membership checks should require `VertexSet`
+/// in addition to `Successors`.
+impl Successors with fn dfs_fold(self, start, init, f) {
+  let visited : Map[Int, Bool] = Map([])
+  let stack : Array[Int] = [start]
+  let mut acc = init
+  while stack.length() > 0 {
+    let v = stack.unsafe_pop()
+    if visited.contains(v) {
+      continue
+    }
+    visited[v] = true
+    let result = f(acc, v)
+    acc = result.0
+    if !result.1 {
+      break
+    }
+    let mark = stack.length()
+    Successors::each_successor(self, v, fn(w) {
+      if !visited.contains(w) {
+        stack.push(w)
+      }
+    })
+    let mut lo = mark
+    let mut hi = stack.length() - 1
+    while lo < hi {
+      let tmp = stack[lo]
+      stack[lo] = stack[hi]
+      stack[hi] = tmp
+      lo = lo + 1
+      hi = hi - 1
+    }
+  }
+  acc
+}
+
+///|
+/// Default bfs_fold: BFS with `Map[Int, Bool]` visited set.
+/// Array-based FIFO queue with head pointer. Override for types that
+/// can provide O(1) visited-set tracking (e.g. `FixedArray[Bool]` for dense IDs).
+///
+/// Same "known start" caveat as `dfs_fold` — does not validate membership.
+impl Successors with fn bfs_fold(self, start, init, f) {
+  let visited : Map[Int, Bool] = Map([])
+  let queue : Array[Int] = [start]
+  visited[start] = true
+  let mut acc = init
+  let mut head = 0
+  while head < queue.length() {
+    let v = queue[head]
+    head = head + 1
+    let result = f(acc, v)
+    acc = result.0
+    if !result.1 {
+      break
+    }
+    Successors::each_successor(self, v, fn(w) {
+      if !visited.contains(w) {
+        visited[w] = true
+        queue.push(w)
+      }
+    })
+  }
+  acc
+}
+
+// ============================================================
+// DirectedGraph — convenience alias
+// ============================================================
+
+///|
+/// Convenience trait: `VertexSet + Successors`.
+///
+/// Use this bound when an algorithm needs both vertex enumeration
+/// AND edge traversal. Most algorithms (toposort, SCC, dfs_events)
+/// require `DirectedGraph`. Local reachability and BFS/DFS from a
+/// known start only need `Successors`.
+///
+/// Implementors: implement `VertexSet` and `Successors` separately,
+/// then add `impl DirectedGraph for YourType` (no methods needed).
+pub(open) trait DirectedGraph: VertexSet + Successors {}
+
+// ============================================================
+// Predecessors — reverse-direction observation capability
+// ============================================================
+
+///|
 /// Types that can efficiently answer "which vertices point to v?"
 /// implement this trait alongside `DirectedGraph`. No default
 /// implementation is provided — an O(V+E) scan default would be
@@ -92,5 +223,5 @@ impl DirectedGraph with has_vertex(self, v) {
 ///
 /// Used by `Reversed[G]` to swap `successors` and `predecessors`.
 pub(open) trait Predecessors {
-  predecessors(Self, Int) -> Iter[Int]
+  fn predecessors(Self, Int) -> Iter[Int]
 }


### PR DESCRIPTION
## Summary

Split the monolithic `DirectedGraph` trait into two fine-grained capability traits: `VertexSet` (vertex enumeration) and `Successors` (edge traversal). `DirectedGraph` remains as an empty alias (`VertexSet + Successors`) for backward compatibility.

## Motivation

Types that can follow edges but cannot enumerate all vertices (implicit graphs, pure functions, infinite streams) can now implement only `Successors` and still run local reachability, BFS/DFS, and outdegree queries.

## Design

```moonbit
pub(open) trait VertexSet {
  fn iter(Self) -> Iter[Int]
  fn each_vertex(Self, (Int) -> Unit) -> Unit = _
  fn vertex_count(Self) -> Int = _
  fn has_vertex(Self, Int) -> Bool = _
}

pub(open) trait Successors {
  fn successors(Self, Int) -> Iter[Int]
  fn[Acc] dfs_fold(Self, Int, Acc, (Acc, Int) -> (Acc, Bool)) -> Acc = _
  fn[Acc] bfs_fold(Self, Int, Acc, (Acc, Int) -> (Acc, Bool)) -> Acc = _
  fn each_successor(Self, Int, (Int) -> Unit) -> Unit = _
}

pub(open) trait DirectedGraph : VertexSet + Successors {}
```

## Key changes

- **Polymorphic fold methods** on `Successors` with `Map[Int,Bool]` defaults, `FixedArray[Bool]` overrides on `DenseGraph`
- **All impls split** into separate `VertexSet` + `Successors` + `DirectedGraph` marker blocks
- **`Reversed[G]` bounds tightened**: `VertexSet for Reversed` now needs only `G : VertexSet` (was `G : DirectedGraph + Predecessors`)
- **Narrowed bounds**: `outdegree` and `reachable` from `DirectedGraph` → `Successors`
- **Added `SuccessorsOnly` blackbox conformance test**
- Review: parallel-review passed (4 agents, 0 critical remaining)

## Breaking

External implementors must migrate from:
```moonbit
impl DirectedGraph for MyType with fn iter(self) { ... }
impl DirectedGraph for MyType with fn successors(self, v) { ... }
```
To:
```moonbit
impl VertexSet for MyType with fn iter(self) { ... }
impl Successors for MyType with fn successors(self, v) { ... }
impl DirectedGraph for MyType
```

## Test

All 70 tests pass (native).