### PR TITLE
Qualify deprecated graph supertrait calls

### DIFF
--- a/src/bfs.mbt
+++ b/src/bfs.mbt
@@ -73,7 +73,7 @@ pub fn[G : DirectedGraph, Acc] bfs_fold_multi(
   let visited : Map[Int, Bool] = Map([])
   let queue : Array[Int] = []
   for s in starts {
-    if !visited.contains(s) && G::has_vertex(graph, s) {
+    if !visited.contains(s) && VertexSet::has_vertex(graph, s) {
       visited[s] = true
       queue.push(s)
     }
@@ -88,7 +88,7 @@ pub fn[G : DirectedGraph, Acc] bfs_fold_multi(
     if !result.1 {
       break
     }
-    G::each_successor(graph, v, fn(w) {
+    Successors::each_successor(graph, v, fn(w) {
       if !visited.contains(w) {
         visited[w] = true
         queue.push(w)

--- a/src/conformance.mbt
+++ b/src/conformance.mbt
@@ -63,7 +63,7 @@ pub fn[G : DirectedGraph] check_conformance(graph : G) -> Array[String] {
   let iter_raw : Array[Int] = []
   let iter_set : @hashset.HashSet[Int] = @hashset.HashSet([])
   let dup_reported : @hashset.HashSet[Int] = @hashset.HashSet([])
-  for v in G::iter(graph) {
+  for v in VertexSet::iter(graph) {
     iter_raw.push(v)
     if iter_set.contains(v) {
       // Duplicate — report once per offending vertex, then keep going so
@@ -79,7 +79,7 @@ pub fn[G : DirectedGraph] check_conformance(graph : G) -> Array[String] {
   // Law D: vertex_count agrees with the raw iter count. Defaults to
   // iter().count() so duplicate-iter impls still satisfy this against
   // the default; only a custom override can fail D in isolation.
-  let vc = G::vertex_count(graph)
+  let vc = VertexSet::vertex_count(graph)
   if vc != iter_raw.length() {
     violations.push(
       "Law D: vertex_count() = \{vc} but iter().count() = \{iter_raw.length()}",
@@ -89,7 +89,7 @@ pub fn[G : DirectedGraph] check_conformance(graph : G) -> Array[String] {
   // false for vertices observably outside iter (spot-checked — we can't
   // enumerate the complement).
   for v in iter_set {
-    if !G::has_vertex(graph, v) {
+    if !VertexSet::has_vertex(graph, v) {
       violations.push(
         "Law C: iter() yielded \{v} but has_vertex(\{v}) returned false",
       )
@@ -100,7 +100,7 @@ pub fn[G : DirectedGraph] check_conformance(graph : G) -> Array[String] {
   // and require has_vertex returns false.
   let outside = outside_candidates(iter_set)
   for v in outside {
-    if G::has_vertex(graph, v) {
+    if VertexSet::has_vertex(graph, v) {
       violations.push(
         "Law C: has_vertex(\{v}) returned true but \{v} is not in iter()",
       )
@@ -109,7 +109,7 @@ pub fn[G : DirectedGraph] check_conformance(graph : G) -> Array[String] {
   // Laws B + E: successors closure + no duplicates.
   for v in iter_set {
     let succ_seen : @hashset.HashSet[Int] = @hashset.HashSet([])
-    for w in G::successors(graph, v) {
+    for w in Successors::successors(graph, v) {
       if succ_seen.contains(w) {
         violations.push("Law E: successors(\{v}) yielded duplicate vertex \{w}")
       } else {
@@ -124,7 +124,7 @@ pub fn[G : DirectedGraph] check_conformance(graph : G) -> Array[String] {
   }
   // Law F: each_vertex agrees with iter() as a multiset (duplicates and all).
   let ev_list : Array[Int] = []
-  G::each_vertex(graph, fn(v) { ev_list.push(v) })
+  VertexSet::each_vertex(graph, fn(v) { ev_list.push(v) })
   if !multiset_eq(ev_list, iter_raw) {
     violations.push(
       "Law F: each_vertex visited \{ev_list.length()} vertices, iter() yielded \{iter_raw.length()}; multisets differ",
@@ -133,8 +133,8 @@ pub fn[G : DirectedGraph] check_conformance(graph : G) -> Array[String] {
   // Law F cont'd: each_successor agrees with successors() for each vertex.
   for v in iter_set {
     let es_list : Array[Int] = []
-    G::each_successor(graph, v, fn(w) { es_list.push(w) })
-    let su_list : Array[Int] = G::successors(graph, v).collect()
+    Successors::each_successor(graph, v, fn(w) { es_list.push(w) })
+    let su_list : Array[Int] = Successors::successors(graph, v).collect()
     if !multiset_eq(es_list, su_list) {
       violations.push(
         "Law F: each_successor(\{v}) visited \{es_list.length()} vertices, successors(\{v}) yielded \{su_list.length()}; multisets differ",
@@ -191,11 +191,11 @@ pub fn[G : DirectedGraph + Predecessors] check_predecessors_conformance(
 ) -> Array[String] {
   let violations = check_conformance(graph)
   // Collect vertices once — no need to re-run iter duplicate check.
-  let iter_list : Array[Int] = G::iter(graph).collect()
+  let iter_list : Array[Int] = VertexSet::iter(graph).collect()
   // Build forward edge set: (u, v) for v ∈ successors(u).
   let forward : @hashset.HashSet[(Int, Int)] = @hashset.HashSet([])
   for u in iter_list {
-    for v in G::successors(graph, u) {
+    for v in Successors::successors(graph, u) {
       forward.add((u, v))
     }
   }

--- a/src/degree.mbt
+++ b/src/degree.mbt
@@ -29,7 +29,7 @@
 ///
 /// Time: O(degree(v)) — counts via `Iter::count` on successors.
 pub fn[G : Successors] outdegree(graph : G, v : Int) -> Int {
-  G::successors(graph, v).count()
+  Successors::successors(graph, v).count()
 }
 
 ///|
@@ -43,8 +43,12 @@ pub fn[G : Successors] outdegree(graph : G, v : Int) -> Int {
 /// For bulk indegree computation, prefer a single-pass array approach.
 pub fn[G : DirectedGraph] indegree(graph : G, v : Int) -> Int {
   let mut count = 0
-  G::each_vertex(graph, fn(u) {
-    G::each_successor(graph, u, fn(w) { if w == v { count = count + 1 } })
+  VertexSet::each_vertex(graph, fn(u) {
+    Successors::each_successor(graph, u, fn(w) {
+      if w == v {
+        count = count + 1
+      }
+    })
   })
   count
 }

--- a/src/dfs.mbt
+++ b/src/dfs.mbt
@@ -65,7 +65,7 @@ pub fn[G : Successors] reachable(graph : G, start : Int) -> Array[Int] {
 /// Time: O(V' + E') where V' and E' are the vertices and edges visited
 /// before encountering `to` (bounded by the reachable subgraph from `from`).
 pub fn[G : DirectedGraph] is_reachable(graph : G, from : Int, to : Int) -> Bool {
-  if !G::has_vertex(graph, from) {
+  if !VertexSet::has_vertex(graph, from) {
     return false
   }
   dfs_fold(graph, from, false, fn(_, v) {
@@ -143,7 +143,7 @@ pub fn[G : DirectedGraph, Acc] dfs_fold_multi(
   let seen : @hashset.HashSet[Int] = @hashset.HashSet([])
   for i in (starts.length() - 1)>=..0 {
     let s = starts[i]
-    if !seen.contains(s) && G::has_vertex(graph, s) {
+    if !seen.contains(s) && VertexSet::has_vertex(graph, s) {
       seen.add(s)
       stack.push(s)
     }
@@ -163,7 +163,7 @@ pub fn[G : DirectedGraph, Acc] dfs_fold_multi(
     // Push successors directly, then reverse in place so first successor
     // is on top of the stack. Avoids per-vertex temporary array allocation.
     let mark = stack.length()
-    G::each_successor(graph, v, fn(w) {
+    Successors::each_successor(graph, v, fn(w) {
       if !visited.contains(w) {
         stack.push(w)
       }
@@ -251,7 +251,7 @@ pub fn[G : DirectedGraph] dfs_events(graph : G) -> Iter[DfsEvent] {
   // absent = white (undiscovered), true = gray (on stack), false = black (finished)
   let state : Map[Int, Bool] = Map([])
   let frames : Array[(Int, Iter[Int])] = []
-  let roots = G::iter(graph)
+  let roots = VertexSet::iter(graph)
   // When set, the next event is Discover(v) and a frame is pushed.
   let mut enter_pending : Int? = None
   Iter::new(fn() {
@@ -260,7 +260,7 @@ pub fn[G : DirectedGraph] dfs_events(graph : G) -> Iter[DfsEvent] {
         Some(v) => {
           enter_pending = None
           state[v] = true
-          frames.push((v, G::successors(graph, v)))
+          frames.push((v, Successors::successors(graph, v)))
           break Some(Discover(v))
         }
         None => ()

--- a/src/scc.mbt
+++ b/src/scc.mbt
@@ -72,12 +72,12 @@ pub fn[G : DirectedGraph + Predecessors] kosaraju_scc(
   let visited : Map[Int, Bool] = Map([])
   let finish_order : Array[Int] = []
   let frames : Array[(Int, Iter[Int])] = []
-  for root in G::iter(graph) {
+  for root in VertexSet::iter(graph) {
     if visited.contains(root) {
       continue
     }
     visited[root] = true
-    frames.push((root, G::successors(graph, root)))
+    frames.push((root, Successors::successors(graph, root)))
     while frames.length() > 0 {
       let top_idx = frames.length() - 1
       let v = frames[top_idx].0
@@ -86,7 +86,7 @@ pub fn[G : DirectedGraph + Predecessors] kosaraju_scc(
         Some(w) =>
           if !visited.contains(w) {
             visited[w] = true
-            frames.push((w, G::successors(graph, w)))
+            frames.push((w, Successors::successors(graph, w)))
           }
         None => {
           finish_order.push(v)
@@ -244,14 +244,14 @@ pub fn[G : DirectedGraph] tarjan_scc(graph : G) -> Array[Array[Int]] {
   // internal position. Since the iterator is stored (not recreated), returning
   // to this frame after a "recursive" call resumes where we left off.
   let frames : Array[(Int, Iter[Int])] = []
-  for root in G::iter(graph) {
+  for root in VertexSet::iter(graph) {
     if state.contains(root) {
       continue
     }
     state[root] = (counter, counter, true)
     counter = counter + 1
     scc_stack.push(root)
-    frames.push((root, G::successors(graph, root)))
+    frames.push((root, Successors::successors(graph, root)))
     while frames.length() > 0 {
       let top_idx = frames.length() - 1
       let v = frames[top_idx].0
@@ -263,7 +263,7 @@ pub fn[G : DirectedGraph] tarjan_scc(graph : G) -> Array[Array[Int]] {
             state[w] = (counter, counter, true)
             counter = counter + 1
             scc_stack.push(w)
-            frames.push((w, G::successors(graph, w)))
+            frames.push((w, Successors::successors(graph, w)))
           } else {
             // Back/cross edge: update v's lowlink to w's *index* (not lowlink).
             // Using index is correct — w's lowlink may not be finalized yet

--- a/src/toposort.mbt
+++ b/src/toposort.mbt
@@ -40,9 +40,9 @@
 /// Returns a Map where every vertex has an entry (0 if no incoming edges).
 fn[G : DirectedGraph] compute_in_degrees(graph : G) -> Map[Int, Int] {
   let in_degree : Map[Int, Int] = Map([])
-  G::each_vertex(graph, fn(v) { in_degree[v] = 0 })
-  G::each_vertex(graph, fn(v) {
-    G::each_successor(graph, v, fn(w) {
+  VertexSet::each_vertex(graph, fn(v) { in_degree[v] = 0 })
+  VertexSet::each_vertex(graph, fn(v) {
+    Successors::each_successor(graph, v, fn(w) {
       let d = match in_degree.get(w) {
         Some(n) => n
         None => 0
@@ -76,7 +76,7 @@ pub fn[G : DirectedGraph] toposort(graph : G) -> Array[Int]? {
     let v = queue[head]
     head = head + 1
     result.push(v)
-    G::each_successor(graph, v, fn(w) {
+    Successors::each_successor(graph, v, fn(w) {
       let d = match in_degree.get(w) {
         Some(n) => n
         None => 0
@@ -88,7 +88,7 @@ pub fn[G : DirectedGraph] toposort(graph : G) -> Array[Int]? {
     })
   }
   // Check completeness — incomplete means a cycle exists
-  let vc = G::vertex_count(graph)
+  let vc = VertexSet::vertex_count(graph)
   if result.length() == vc {
     Some(result)
   } else {
@@ -131,13 +131,13 @@ pub fn[G : DirectedGraph] find_cycle(graph : G) -> Array[Int]? {
   // extraction when a back-edge is encountered.
   let position : Map[Int, Int] = Map([])
   let frames : Array[(Int, Iter[Int])] = []
-  for root in G::iter(graph) {
+  for root in VertexSet::iter(graph) {
     if state.contains(root) {
       continue
     }
     state[root] = true
     position[root] = 0
-    frames.push((root, G::successors(graph, root)))
+    frames.push((root, Successors::successors(graph, root)))
     while frames.length() > 0 {
       let top_idx = frames.length() - 1
       let v = frames[top_idx].0
@@ -149,7 +149,7 @@ pub fn[G : DirectedGraph] find_cycle(graph : G) -> Array[Int]? {
               // Tree edge: descend into w
               state[w] = true
               position[w] = frames.length()
-              frames.push((w, G::successors(graph, w)))
+              frames.push((w, Successors::successors(graph, w)))
             }
             Some(true) => {
               // Back edge v -> w: w is an ancestor on the current path.
@@ -263,7 +263,7 @@ pub fn[G : DirectedGraph] topo_levels(graph : G) -> Map[Int, Int]? {
       Some(l) => l
       None => 0
     }
-    G::each_successor(graph, v, fn(w) {
+    Successors::each_successor(graph, v, fn(w) {
       let d = match in_degree.get(w) {
         Some(n) => n
         None => 0
@@ -319,7 +319,7 @@ pub fn[G : DirectedGraph] toposort_subset(
   let subset : @hashset.HashSet[Int] = @hashset.HashSet([])
   let unique : Array[Int] = []
   for v in vertices {
-    if !subset.contains(v) && G::has_vertex(graph, v) {
+    if !subset.contains(v) && VertexSet::has_vertex(graph, v) {
       subset.add(v)
       unique.push(v)
     }
@@ -331,7 +331,7 @@ pub fn[G : DirectedGraph] toposort_subset(
   // Compute in-degrees within the induced subgraph
   let in_degree : @hashmap.HashMap[Int, Int] = @hashmap.HashMap([])
   for v in unique {
-    G::each_successor(graph, v, fn(w) {
+    Successors::each_successor(graph, v, fn(w) {
       if subset.contains(w) {
         match in_degree.get(w) {
           Some(d) => in_degree[w] = d + 1
@@ -354,7 +354,7 @@ pub fn[G : DirectedGraph] toposort_subset(
     let v = queue[head]
     head = head + 1
     result.push(v)
-    G::each_successor(graph, v, fn(w) {
+    Successors::each_successor(graph, v, fn(w) {
       if subset.contains(w) {
         match in_degree.get(w) {
           Some(d) => {


### PR DESCRIPTION
## Summary
- replace deprecated generic `G::` supertrait dispatch with `VertexSet::` and `Successors::` static calls
- preserve graph algorithms and public API

## Scope
Only six warning-emitting graph algorithm files. `src/reversed.mbt` is intentionally out of scope.

## Validation
- `moon fmt`
- `moon check --deny-warn`
- `moon test` (238 tests)
- `moon info`
- `git diff --check`
- `moonbit-reviewer`: PASS